### PR TITLE
Tun review

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,6 +22,11 @@ services:
       - ~/.m2:/root/.m2
       - ..:/code
     working_dir: /code
+    # required by TunChannel
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
 
   build-leak:
     <<: *common

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -175,6 +175,19 @@
       <groupId>com.sun.activation</groupId>
       <artifactId>javax.activation</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-classes-kqueue</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -198,5 +211,65 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>native-dependencies</id>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-x86_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-aarch_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-x86_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-aarch_64</classifier>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>linux</id>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>mac</id>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>
 

--- a/example/src/main/java/io/netty/example/tun/Echo4Handler.java
+++ b/example/src/main/java/io/netty/example/tun/Echo4Handler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tun;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.Tun4Packet;
+import io.netty.channel.socket.TunPacket;
+
+import static io.netty.channel.socket.Tun4Packet.INET4_DESTINATION_ADDRESS;
+import static io.netty.channel.socket.Tun4Packet.INET4_SOURCE_ADDRESS;
+
+/**
+ * Echoes received IPv4 packets by swapping source and destination addresses.
+ */
+@Sharable
+public class Echo4Handler extends SimpleChannelInboundHandler<Tun4Packet> {
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx,
+                                Tun4Packet packet) throws Exception {
+        // swap source and destination addresses. Depending on the layer 4 protocol used, this may
+        // require recalculation of existing checksums. However, UDP and TCP work without
+        // recalculation.
+        ByteBuf buf = packet.content();
+        int sourceAddress = buf.getInt(INET4_SOURCE_ADDRESS);
+        int destinationAddress = buf.getInt(INET4_DESTINATION_ADDRESS);
+        buf.setInt(INET4_SOURCE_ADDRESS, destinationAddress);
+        buf.setInt(INET4_DESTINATION_ADDRESS, sourceAddress);
+
+        TunPacket response = new Tun4Packet(buf.retain());
+        ctx.write(response);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.fireChannelReadComplete();
+        ctx.flush();
+    }
+}

--- a/example/src/main/java/io/netty/example/tun/Echo6Handler.java
+++ b/example/src/main/java/io/netty/example/tun/Echo6Handler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tun;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.Tun6Packet;
+import io.netty.channel.socket.TunPacket;
+
+import static io.netty.channel.socket.Tun6Packet.INET6_DESTINATION_ADDRESS;
+import static io.netty.channel.socket.Tun6Packet.INET6_SOURCE_ADDRESS;
+
+/**
+ * Echoes received IPv6 packets by swapping source and destination addresses.
+ */
+@Sharable
+public class Echo6Handler extends SimpleChannelInboundHandler<Tun6Packet> {
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx,
+                                Tun6Packet packet) throws Exception {
+        // swap source and destination addresses. Depending on the layer 4 protocol used, this may
+        // require recalculation of existing checksums. However, UDP and TCP work without
+        // recalculation.
+        ByteBuf buf = packet.content();
+        byte[] sourceAddress = new byte[16];
+        buf.getBytes(INET6_SOURCE_ADDRESS, sourceAddress, 0, 16);
+        byte[] destinationAddress = new byte[16];
+        buf.getBytes(INET6_DESTINATION_ADDRESS, destinationAddress, 0, 16);
+        buf.setBytes(INET6_SOURCE_ADDRESS, destinationAddress);
+        buf.setBytes(INET6_DESTINATION_ADDRESS, sourceAddress);
+
+        TunPacket response = new Tun6Packet(buf.retain());
+        ctx.write(response);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.fireChannelReadComplete();
+        ctx.flush();
+    }
+}

--- a/example/src/main/java/io/netty/example/tun/Ping4Handler.java
+++ b/example/src/main/java/io/netty/example/tun/Ping4Handler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tun;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.Tun4Packet;
+import io.netty.channel.socket.TunPacket;
+
+import java.net.InetAddress;
+
+import static io.netty.channel.socket.Tun4Packet.INET4_DESTINATION_ADDRESS;
+import static io.netty.channel.socket.Tun4Packet.INET4_SOURCE_ADDRESS;
+
+/**
+ * Replies to ICMP echo ping requests.
+ */
+@Sharable
+public class Ping4Handler extends SimpleChannelInboundHandler<Tun4Packet> {
+    // https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+    public static final int PROTOCOL = 1;
+    // https://datatracker.ietf.org/doc/html/rfc792
+    public static final int TYPE = 20;
+    public static final int CHECKSUM = 22;
+    public static final int ECHO = 8;
+    public static final int ECHO_REPLY = 0;
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx,
+                                Tun4Packet packet) {
+        if (packet.protocol() == PROTOCOL) {
+            short icmpType = packet.content().getUnsignedByte(TYPE);
+            if (icmpType == ECHO) {
+                InetAddress source = packet.sourceAddress();
+                InetAddress destination = packet.destinationAddress();
+                int checksum = packet.content().getUnsignedShort(CHECKSUM);
+
+                // create response
+                ByteBuf buf = packet.content();
+                buf.setBytes(INET4_SOURCE_ADDRESS, destination.getAddress());
+                buf.setBytes(INET4_DESTINATION_ADDRESS, source.getAddress());
+                buf.setByte(TYPE, ECHO_REPLY);
+                buf.setShort(CHECKSUM, (checksum + 0x0800) % 0xffff);
+
+                TunPacket response = new Tun4Packet(buf.retain());
+                ctx.writeAndFlush(response);
+            }
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/tun/Ping6Handler.java
+++ b/example/src/main/java/io/netty/example/tun/Ping6Handler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tun;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.Tun6Packet;
+import io.netty.channel.socket.TunPacket;
+
+import java.net.InetAddress;
+
+import static io.netty.channel.socket.Tun6Packet.INET6_DESTINATION_ADDRESS;
+import static io.netty.channel.socket.Tun6Packet.INET6_SOURCE_ADDRESS;
+
+/**
+ * Replies to IPv6-ICMP echo ping requests.
+ */
+@Sharable
+public class Ping6Handler extends SimpleChannelInboundHandler<Tun6Packet> {
+    // https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+    public static final int PROTOCOL = 58;
+    // https://datatracker.ietf.org/doc/html/rfc8200
+    public static final int NEXT_HEADER = 6;
+    public static final int TYPE = 40;
+    public static final int CHECKSUM = 42;
+    public static final int ECHO = 128;
+    public static final int ECHO_REPLY = 129;
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx,
+                                Tun6Packet packet) {
+        int nextHeader = packet.content().getUnsignedByte(NEXT_HEADER);
+        if (nextHeader == PROTOCOL) {
+            short icmpType = packet.content().getUnsignedByte(TYPE);
+            if (icmpType == ECHO) {
+                InetAddress source = packet.sourceAddress();
+                InetAddress destination = packet.destinationAddress();
+                int checksum = packet.content().getUnsignedShort(CHECKSUM);
+
+                // create response
+                ByteBuf buf = packet.content();
+                buf.setBytes(INET6_SOURCE_ADDRESS, destination.getAddress());
+                buf.setBytes(INET6_DESTINATION_ADDRESS, source.getAddress());
+                buf.setByte(TYPE, ECHO_REPLY);
+                buf.setShort(CHECKSUM, checksum - 0x100);
+
+                TunPacket response = new Tun6Packet(buf.retain());
+                ctx.writeAndFlush(response);
+            }
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/tun/TunEchoDevice.java
+++ b/example/src/main/java/io/netty/example/tun/TunEchoDevice.java
@@ -105,7 +105,7 @@ public final class TunEchoDevice {
                     });
             Channel ch = b.bind(new TunAddress(NAME)).syncUninterruptibly().channel();
 
-            String name = ch.localAddress().toString();
+            String name = ((TunAddress) ch.localAddress()).ifName();
             System.out.println("TUN device created: " + name);
 
             if (PlatformDependent.isOsx()) {

--- a/example/src/main/java/io/netty/example/tun/TunEchoDevice.java
+++ b/example/src/main/java/io/netty/example/tun/TunEchoDevice.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tun;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollTunChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueTunChannel;
+import io.netty.channel.socket.TunAddress;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.netty.channel.kqueue.KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS;
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+
+/**
+ * Creates a TUN device that echoes back all received IP packets.
+ * <p/>
+ * <h2>Usage Example:</h2>
+ *
+ * <pre>
+ *     ./run-example tun-echo-device -Daddress=10.10.10.10 -Dnetmask=24 -Dmtu=1500
+ * </pre>
+ *
+ * In a second shell:
+ * <pre>
+ *     iperf3 --server
+ * </pre>
+ *
+ * In a third shell:
+ * <pre>
+ *     iperf3 --client 10.10.10.11
+ * </pre>
+ */
+public final class TunEchoDevice {
+    static final String NAME = System.getProperty("name", null);
+    static final InetAddress ADDRESS;
+    static final int NETMASK = Integer.parseInt(System.getProperty("netmask", "24"));
+    static final int MTU = Integer.parseInt(System.getProperty("mtu", "1500"));
+
+    static {
+        try {
+            ADDRESS = InetAddress.getByName(System.getProperty("address", "10.10.10.10"));
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup group;
+        Class<? extends Channel> channelClass;
+        if (KQueue.isAvailable()) {
+            group = new KQueueEventLoopGroup(1);
+            channelClass = KQueueTunChannel.class;
+        } else if (Epoll.isAvailable()) {
+            group = new EpollEventLoopGroup(1);
+            channelClass = EpollTunChannel.class;
+        } else {
+            throw new RuntimeException("Unsupported platform: Neither kqueue nor epoll are available");
+        }
+
+        try {
+            Bootstrap b = new Bootstrap()
+                    .group(group)
+                    .channel(channelClass)
+                    .option(TUN_MTU, MTU)
+                    .option(RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(MTU)) // used by epoll
+                    .option(RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, true) // used by kqueue
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ChannelPipeline p = ch.pipeline();
+
+                            p.addLast(new Echo4Handler());
+                            p.addLast(new Echo6Handler());
+                        }
+                    });
+            Channel ch = b.bind(new TunAddress(NAME)).syncUninterruptibly().channel();
+
+            String name = ch.localAddress().toString();
+            System.out.println("TUN device created: " + name);
+
+            if (PlatformDependent.isOsx()) {
+                if (ADDRESS instanceof Inet6Address) {
+                    exec("/sbin/ifconfig", name, "inet6", "add", ADDRESS.getHostAddress() + "/" + NETMASK);
+                    exec("/sbin/route", "add", "-inet6", ADDRESS.getHostAddress(), "-iface", name);
+                } else {
+                    exec("/sbin/ifconfig", name, "add", ADDRESS.getHostAddress(), ADDRESS.getHostAddress());
+                    exec("/sbin/route", "add", "-net", ADDRESS.getHostAddress() + '/' + NETMASK, "-iface", name);
+                }
+            } else if (!PlatformDependent.isWindows()) {
+                String version = ADDRESS instanceof Inet6Address ? "-6" : "-4";
+                exec("/sbin/ip", version, "addr", "add", ADDRESS.getHostAddress() + '/' + NETMASK, "dev", name);
+                exec("/sbin/ip", "link", "set", "dev", name, "up");
+            }
+
+            System.out.println("Address and netmask assigned: " + ADDRESS.getHostAddress() + '/' + NETMASK);
+            System.out.println("All IP packets addressed to this subnet "
+                    + (PlatformDependent.isOsx() ? "" : "(except for " + ADDRESS.getHostAddress() + ") ")
+                    + "should now be echoed back.");
+
+            ch.closeFuture().syncUninterruptibly();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void exec(String... command) throws IOException {
+        try {
+            int exitCode = Runtime.getRuntime().exec(command).waitFor();
+            if (exitCode != 0) {
+                CharSequence arguments = StringUtil.join(" ", Arrays.asList(command));
+                throw new IOException("Executing `" + arguments + "` returned non-zero exit code (" + exitCode + ").");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/tun/TunEchoDevice.java
+++ b/example/src/main/java/io/netty/example/tun/TunEchoDevice.java
@@ -85,7 +85,7 @@ public final class TunEchoDevice {
         EventLoopGroup group;
         Class<? extends Channel> channelClass;
         if (KQueue.isAvailable()) {
-            if (QUEUES > 0) {
+            if (QUEUES > 1) {
                 throw new RuntimeException("Parallel reading and writing is only supported with epoll");
             }
             group = new KQueueEventLoopGroup(1);

--- a/example/src/main/java/io/netty/example/tun/TunPingDevice.java
+++ b/example/src/main/java/io/netty/example/tun/TunPingDevice.java
@@ -103,7 +103,7 @@ public final class TunPingDevice {
                     });
             Channel ch = b.bind(new TunAddress(NAME)).syncUninterruptibly().channel();
 
-            String name = ch.localAddress().toString();
+            String name = ((TunAddress) ch.localAddress()).ifName();
             System.out.println("TUN device created: " + name);
 
             if (PlatformDependent.isOsx()) {

--- a/example/src/main/java/io/netty/example/tun/TunPingDevice.java
+++ b/example/src/main/java/io/netty/example/tun/TunPingDevice.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tun;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollTunChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueTunChannel;
+import io.netty.channel.socket.TunAddress;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.netty.channel.kqueue.KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS;
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+
+/**
+ * Creates a TUN device that replies to received ICMP echo requests.
+ * <p/>
+ * <h2>Usage:</h2>
+ *
+ * <pre>
+ *     ./run-example tun-ping-device -Daddress=fc00::1 -Dnetmask=120 -Dmtu=1500
+ * </pre>
+ *
+ * In another shell:
+ * <pre>
+ *     ping6 fc00:0:0:0:0:0:0:2
+ * </pre>
+ */
+public final class TunPingDevice {
+    static final String NAME = System.getProperty("name", null);
+    static final InetAddress ADDRESS;
+    static final int NETMASK = Integer.parseInt(System.getProperty("netmask", "24"));
+    static final int MTU = Integer.parseInt(System.getProperty("mtu", "1500"));
+
+    static {
+        try {
+            ADDRESS = InetAddress.getByName(System.getProperty("address", "10.10.10.10"));
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup group;
+        Class<? extends Channel> channelClass;
+        if (KQueue.isAvailable()) {
+            group = new KQueueEventLoopGroup(1);
+            channelClass = KQueueTunChannel.class;
+        } else if (Epoll.isAvailable()) {
+            group = new EpollEventLoopGroup(1);
+            channelClass = EpollTunChannel.class;
+        } else {
+            throw new RuntimeException("Unsupported platform: Neither kqueue nor epoll are available");
+        }
+
+        try {
+            Bootstrap b = new Bootstrap()
+                    .group(group)
+                    .channel(channelClass)
+                    .option(TUN_MTU, MTU)
+                    .option(RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(MTU)) // used by epoll
+                    .option(RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, true) // used by kqueue
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ChannelPipeline p = ch.pipeline();
+
+                            p.addLast(new LoggingHandler(LogLevel.INFO));
+                            p.addLast(new Ping4Handler());
+                            p.addLast(new Ping6Handler());
+                        }
+                    });
+            Channel ch = b.bind(new TunAddress(NAME)).syncUninterruptibly().channel();
+
+            String name = ch.localAddress().toString();
+            System.out.println("TUN device created: " + name);
+
+            if (PlatformDependent.isOsx()) {
+                if (ADDRESS instanceof Inet6Address) {
+                    exec("/sbin/ifconfig", name, "inet6", "add", ADDRESS.getHostAddress() + "/" + NETMASK);
+                    exec("/sbin/route", "add", "-inet6", ADDRESS.getHostAddress(), "-iface", name);
+                } else {
+                    exec("/sbin/ifconfig", name, "add", ADDRESS.getHostAddress(), ADDRESS.getHostAddress());
+                    exec("/sbin/route", "add", "-net", ADDRESS.getHostAddress() + '/' + NETMASK, "-iface", name);
+                }
+            } else if (!PlatformDependent.isWindows()) {
+                String version = ADDRESS instanceof Inet6Address ? "-6" : "-4";
+                exec("/sbin/ip", version, "addr", "add", ADDRESS.getHostAddress() + '/' + NETMASK, "dev", name);
+                exec("/sbin/ip", "link", "set", "dev", name, "up");
+            }
+
+            System.out.println("Address and netmask assigned: " + ADDRESS.getHostAddress() + '/' + NETMASK);
+            System.out.println("All ICMP echo ping requests addressed to this subnet "
+                    + (PlatformDependent.isOsx() ? "" : "(except for " + ADDRESS.getHostAddress() + ") ")
+                    + "should now be replied to.");
+
+            ch.closeFuture().syncUninterruptibly();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void exec(String... command) throws IOException {
+        try {
+            int exitCode = Runtime.getRuntime().exec(command).waitFor();
+            if (exitCode != 0) {
+                CharSequence arguments = StringUtil.join(" ", Arrays.asList(command));
+                throw new IOException("Executing `" + arguments + "` returned non-zero exit code (" + exitCode + ").");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/run-example.sh
+++ b/run-example.sh
@@ -52,6 +52,8 @@ EXAMPLE_MAP=(
   'socksproxy-server:io.netty.example.socksproxy.SocksServer'
   'memcache-binary-client:io.netty.example.memcache.binary.MemcacheClient'
   'stomp-client:io.netty.example.stomp.StompClient'
+  'tun-ping-device:io.netty.example.tun.TunPingDevice'
+  'tun-echo-device:io.netty.example.tun.TunEchoDevice'
   'uptime-client:io.netty.example.uptime.UptimeClient'
   'uptime-server:io.netty.example.uptime.UptimeServer'
   'sctpecho-client:io.netty.example.sctp.SctpEchoClient'
@@ -128,6 +130,17 @@ for E in "${NEEDS_NPN_MAP[@]}"; do
   fi
 done
 
+OS="$(uname)"
+if [[ "${OS}" == "Linux" ]]
+then
+  PROFILE="-P linux"
+elif [[ "${OS}" == "Darwin" ]]
+then
+  PROFILE="-P mac"
+else
+  PROFILE=""
+fi
+
 cd "`dirname "$0"`"/example
 echo "[INFO] Running: $EXAMPLE ($EXAMPLE_CLASS $EXAMPLE_ARGS)"
-exec mvn -q -nsu compile exec:exec -Dcheckstyle.skip=true -Dforbiddenapis.skip=true -Dforcenpn="$FORCE_NPN" -DargLine.example="$EXAMPLE_ARGS" -DexampleClass="$EXAMPLE_CLASS"
+exec mvn -q $PROFILE -nsu compile exec:exec -Dcheckstyle.skip=true -Dforbiddenapis.skip=true -Dforcenpn="$FORCE_NPN" -DargLine.example="$EXAMPLE_ARGS" -DexampleClass="$EXAMPLE_CLASS"

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-example</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TunChannelTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TunChannelTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite.transport.socket;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.TunAddress;
+import io.netty.channel.socket.TunChannel;
+import io.netty.example.tun.Echo4Handler;
+import io.netty.util.internal.StringUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+
+/**
+ * This test creates a TUN device that echoes back all received IPv4 packets and a {@link DatagramChannel}
+ * that sends random data and checks if it was echoed back.
+ */
+public abstract class TunChannelTest {
+    private static final String ADDRESS = "10.1.29.60";
+    private static final int NETMASK = 30;
+    private static final String RECIPIENT = "10.1.29.61";
+    private static final int BUF_LEN = 500;
+    private static final int BUF_COUNT = 5;
+    private final Random rand;
+    private final EventLoopGroup group;
+    private final Class<? extends TunChannel> tunChannelClass;
+    private final Class<? extends DatagramChannel> udpChannelClass;
+
+    protected TunChannelTest(EventLoopGroup group,
+                             Class<? extends TunChannel> tunChannelClass,
+                             Class<? extends DatagramChannel> udpChannelClass) {
+        this.rand = new Random();
+        this.group = group;
+        this.tunChannelClass = tunChannelClass;
+        this.udpChannelClass = udpChannelClass;
+    }
+
+    @AfterEach
+    void tearDown() {
+        group.shutdownGracefully();
+    }
+
+    @Test
+    void testEchoIpPackets() throws InterruptedException, IOException {
+        Channel tunCh = null;
+        Channel udpCh = null;
+
+        try {
+            // create tun device
+            tunCh = new Bootstrap()
+                    .group(group)
+                    .channel(tunChannelClass)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ChannelPipeline p = ch.pipeline();
+                            p.addLast(new Echo4Handler());
+                        }
+                    }).bind(new TunAddress()).syncUninterruptibly().channel();
+
+            // assign ip address/netmask to tun device
+            String name = ((TunAddress) tunCh.localAddress()).ifName();
+            attachAddressAndNetmask(name, ADDRESS, NETMASK);
+
+            // create udp channel
+            final CountDownLatch latch = new CountDownLatch(BUF_COUNT);
+            udpCh = new Bootstrap()
+                    .group(group)
+                    .channel(udpChannelClass)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ChannelPipeline p = ch.pipeline();
+                            p.addLast(new PingHandler(latch));
+                        }
+                    }).bind(0).syncUninterruptibly().channel();
+            latch.await();
+        } finally {
+            if (tunCh != null) {
+                tunCh.close().sync();
+            }
+            if (udpCh != null) {
+                udpCh.close().sync();
+            }
+            group.shutdownGracefully().sync();
+        }
+    }
+
+    protected abstract void attachAddressAndNetmask(String name, String address, int netmask) throws IOException;
+
+    protected static void exec(String... command) throws IOException {
+        try {
+            int exitCode = Runtime.getRuntime().exec(command).waitFor();
+            if (exitCode != 0) {
+                CharSequence arguments = StringUtil.join(" ", Arrays.asList(command));
+                throw new IOException("Executing `" + arguments + "` returned non-zero exit code (" + exitCode + ").");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private final class PingHandler extends SimpleChannelInboundHandler<DatagramPacket> {
+        private final CountDownLatch latch;
+        private ByteBuf buf;
+        private InetSocketAddress recipient;
+
+        PingHandler(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            ctx.fireChannelActive();
+
+            // use same port for sender and recipient as Echo4Handler only swap addresses
+            final int port = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
+            recipient = new InetSocketAddress(RECIPIENT, port);
+
+            sendBuf(ctx);
+        }
+
+        @Override
+        public void channelInactive(final ChannelHandlerContext ctx) {
+            buf.release();
+            ctx.fireChannelInactive();
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx,
+                                    DatagramPacket msg) {
+            if (buf.equals(msg.content())) {
+                latch.countDown();
+                sendBuf(ctx);
+            }
+        }
+
+        private void sendBuf(ChannelHandlerContext ctx) {
+            final byte[] bytes = new byte[BUF_LEN];
+            rand.nextBytes(bytes);
+            buf = wrappedBuffer(bytes);
+            ctx.writeAndFlush(new DatagramPacket(buf.retain(), recipient));
+        }
+    }
+}

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -67,7 +67,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     private Future<?> connectTimeoutFuture;
     private SocketAddress requestedRemoteAddress;
 
-    private volatile SocketAddress local;
+    protected volatile SocketAddress local;
     private volatile SocketAddress remote;
 
     protected int flags = Native.EPOLLET;
@@ -341,7 +341,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     /**
      * Read bytes into the given {@link ByteBuf} and return the amount.
      */
-    protected final int doReadBytes(ByteBuf byteBuf) throws Exception {
+    protected int doReadBytes(ByteBuf byteBuf) throws Exception {
         int writerIndex = byteBuf.writerIndex();
         int localReadAmount;
         unsafe().recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
@@ -357,7 +357,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         return localReadAmount;
     }
 
-    protected final int doWriteBytes(ChannelOutboundBuffer in, ByteBuf buf) throws Exception {
+    protected int doWriteBytes(ChannelOutboundBuffer in, ByteBuf buf) throws Exception {
         if (buf.hasMemoryAddress()) {
             int localFlushedAmount = socket.sendAddress(buf.memoryAddress(), buf.readerIndex(), buf.writerIndex());
             if (localFlushedAmount > 0) {
@@ -381,7 +381,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
      * Write bytes to the socket, with or without a remote address.
      * Used for datagram and TCP client fast open writes.
      */
-    final long doWriteOrSendBytes(ByteBuf data, InetSocketAddress remoteAddress, boolean fastOpen)
+    long doWriteOrSendBytes(ByteBuf data, InetSocketAddress remoteAddress, boolean fastOpen)
             throws IOException {
         assert !(fastOpen && remoteAddress == null) : "fastOpen requires a remote address";
         if (data.hasMemoryAddress()) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannel.java
@@ -36,6 +36,7 @@ import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 
+import static io.netty.channel.epoll.EpollTunChannelOption.IFF_MULTI_QUEUE;
 import static io.netty.channel.epoll.LinuxSocket.newSocketTun;
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
@@ -238,7 +239,8 @@ public class EpollTunChannel extends AbstractEpollChannel implements TunChannel 
     @Override
     protected void doBind(SocketAddress local) throws Exception {
         // TUN device must be bound before adding to EpollEventLoop
-        this.local = socket.bindTun(local);
+        final boolean multiqueue = config.getOption(IFF_MULTI_QUEUE);
+        this.local = socket.bindTun(local, multiqueue);
         super.doRegister();
         active = true;
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannel.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.Tun4Packet;
+import io.netty.channel.socket.Tun6Packet;
+import io.netty.channel.socket.TunAddress;
+import io.netty.channel.socket.TunChannel;
+import io.netty.channel.socket.TunPacket;
+import io.netty.channel.unix.Errors;
+import io.netty.channel.unix.IovArray;
+import io.netty.channel.unix.UnixChannelUtil;
+import io.netty.util.UncheckedBooleanSupplier;
+import io.netty.util.internal.StringUtil;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+
+import static io.netty.channel.epoll.LinuxSocket.newSocketTun;
+import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+
+/**
+ * {@link TunChannel} implementation that uses linux epoll edge-triggered mode for maximal
+ * performance.
+ */
+public class EpollTunChannel extends AbstractEpollChannel implements TunChannel {
+    private static final String EXPECTED_TYPES =
+            " (expected: " + StringUtil.simpleClassName(TunPacket.class) + ", " +
+                    StringUtil.simpleClassName(ByteBuf.class) + ')';
+    private final EpollTunChannelConfig config;
+
+    public EpollTunChannel() {
+        super(null, newSocketTun(), false);
+        this.config = new EpollTunChannelConfig(this);
+    }
+
+    /**
+     * Read bytes into the given {@link ByteBuf} and return the amount.
+     */
+    @Override
+    protected int doReadBytes(ByteBuf byteBuf) throws Exception {
+        int writerIndex = byteBuf.writerIndex();
+        int localReadAmount;
+        unsafe().recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
+        if (byteBuf.hasMemoryAddress()) {
+            localReadAmount = socket.readAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
+        } else {
+            ByteBuffer buf = byteBuf.internalNioBuffer(writerIndex, byteBuf.writableBytes());
+            localReadAmount = socket.read(buf, buf.position(), buf.limit());
+        }
+        if (localReadAmount > 0) {
+            byteBuf.writerIndex(writerIndex + localReadAmount);
+        }
+        return localReadAmount;
+    }
+
+    @Override
+    protected void doWrite(final ChannelOutboundBuffer in) throws Exception {
+        int maxMessagesPerWrite = maxMessagesPerWrite();
+        while (maxMessagesPerWrite > 0) {
+            Object msg = in.current();
+            if (msg == null) {
+                // Wrote all messages.
+                break;
+            }
+
+            boolean done = false;
+            for (int i = config().getWriteSpinCount(); i > 0; --i) {
+                if (doWriteMessage(msg)) {
+                    done = true;
+                    break;
+                }
+            }
+
+            if (done) {
+                in.remove();
+                maxMessagesPerWrite--;
+            } else {
+                break;
+            }
+        }
+
+        if (in.isEmpty()) {
+            // Did write all messages.
+            clearFlag(Native.EPOLLOUT);
+        } else {
+            // Did not write all messages.
+            setFlag(Native.EPOLLOUT);
+        }
+    }
+
+    private boolean doWriteMessage(Object msg) throws Exception {
+        final ByteBuf data;
+        if (msg instanceof TunPacket) {
+            TunPacket packet = (TunPacket) msg;
+            data = packet.content();
+        } else {
+            data = (ByteBuf) msg;
+        }
+
+        final int dataLen = data.readableBytes();
+        if (dataLen == 0) {
+            return true;
+        }
+
+        return doWriteOrSendBytes(data, null, false) > 0;
+    }
+
+    @Override
+    protected int doWriteBytes(ChannelOutboundBuffer in, ByteBuf buf) throws Exception {
+        if (buf.hasMemoryAddress()) {
+            int localFlushedAmount = socket.writeAddress(buf.memoryAddress(), buf.readerIndex(), buf.writerIndex());
+            if (localFlushedAmount > 0) {
+                in.removeBytes(localFlushedAmount);
+                return 1;
+            }
+        } else {
+            final ByteBuffer nioBuf = buf.nioBufferCount() == 1 ?
+                    buf.internalNioBuffer(buf.readerIndex(), buf.readableBytes()) : buf.nioBuffer();
+            int localFlushedAmount = socket.write(nioBuf, nioBuf.position(), nioBuf.limit());
+            if (localFlushedAmount > 0) {
+                nioBuf.position(nioBuf.position() + localFlushedAmount);
+                in.removeBytes(localFlushedAmount);
+                return 1;
+            }
+        }
+        return WRITE_STATUS_SNDBUF_FULL;
+    }
+
+    /**
+     * Write bytes to the socket, with or without a remote address.
+     */
+    @Override
+    protected long doWriteOrSendBytes(ByteBuf data, InetSocketAddress remoteAddress, boolean fastOpen)
+            throws IOException {
+        assert !(fastOpen && remoteAddress == null) : "fastOpen requires a remote address";
+        if (data.hasMemoryAddress()) {
+            long memoryAddress = data.memoryAddress();
+            if (remoteAddress == null) {
+                return socket.writeAddress(memoryAddress, data.readerIndex(), data.writerIndex());
+            }
+            return socket.sendToAddress(memoryAddress, data.readerIndex(), data.writerIndex(),
+                    remoteAddress.getAddress(), remoteAddress.getPort(), fastOpen);
+        }
+
+        if (data.nioBufferCount() > 1) {
+            IovArray array = ((EpollEventLoop) eventLoop()).cleanIovArray();
+            array.add(data, data.readerIndex(), data.readableBytes());
+            int cnt = array.count();
+            assert cnt != 0;
+
+            if (remoteAddress == null) {
+                return socket.writevAddresses(array.memoryAddress(0), cnt);
+            }
+            return socket.sendToAddresses(array.memoryAddress(0), cnt,
+                    remoteAddress.getAddress(), remoteAddress.getPort(), fastOpen);
+        }
+
+        ByteBuffer nioData = data.internalNioBuffer(data.readerIndex(), data.readableBytes());
+        if (remoteAddress == null) {
+            return socket.write(nioData, nioData.position(), nioData.limit());
+        }
+        return socket.sendTo(nioData, nioData.position(), nioData.limit(),
+                remoteAddress.getAddress(), remoteAddress.getPort(), fastOpen);
+    }
+
+    @Override
+    protected Object filterOutboundMessage(final Object msg) {
+        if (msg instanceof Tun4Packet) {
+            Tun4Packet packet = (Tun4Packet) msg;
+            ByteBuf content = packet.content();
+            return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
+                    new Tun4Packet(newDirectBuffer(packet, content)) : msg;
+        }
+
+        if (msg instanceof Tun6Packet) {
+            Tun6Packet packet = (Tun6Packet) msg;
+            ByteBuf content = packet.content();
+            return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
+                    new Tun6Packet(newDirectBuffer(packet, content)) : msg;
+        }
+
+        if (msg instanceof ByteBuf) {
+            ByteBuf buf = (ByteBuf) msg;
+            return UnixChannelUtil.isBufferCopyNeededForWrite(buf) ? newDirectBuffer(buf) : buf;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
+    }
+
+    @Override
+    public EpollChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public TunAddress localAddress() {
+        return (TunAddress) super.localAddress();
+    }
+
+    @Override
+    public int mtu() throws IOException {
+        return LinuxSocket.getMtu(localAddress().ifName());
+    }
+
+    @Override
+    protected AbstractEpollUnsafe newUnsafe() {
+        return new EpollTunChannelUnsafe();
+    }
+
+    @Override
+    protected void doRegister() {
+        // skip registration at EpollEventLoop, since TUN device must be bound first
+    }
+
+    @Override
+    protected void doBind(SocketAddress local) throws Exception {
+        // TUN device must be bound before adding to EpollEventLoop
+        this.local = socket.bindTun(local);
+        super.doRegister();
+        active = true;
+
+        final int mtu = config.getOption(TUN_MTU);
+        if (mtu > 0) {
+            LinuxSocket.setMtu(((TunAddress) this.local).ifName(), mtu);
+        }
+    }
+
+    final class EpollTunChannelUnsafe extends AbstractEpollUnsafe {
+        @Override
+        void epollInReady() {
+            assert eventLoop().inEventLoop();
+            EpollChannelConfig config = config();
+            if (shouldBreakEpollInReady(config)) {
+                clearEpollIn0();
+                return;
+            }
+            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            allocHandle.edgeTriggered(isFlagSet(Native.EPOLLET));
+
+            final ChannelPipeline pipeline = pipeline();
+            final ByteBufAllocator allocator = config.getAllocator();
+            allocHandle.reset(config);
+            epollInBefore();
+
+            Throwable exception = null;
+            try {
+                ByteBuf byteBuf = null;
+                try {
+                    do {
+                        byteBuf = allocHandle.allocate(allocator);
+                        allocHandle.attemptedBytesRead(byteBuf.writableBytes());
+
+                        final TunPacket packet;
+                        try {
+                            allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                        } catch (Errors.NativeIoException e) {
+                            // We need to correctly translate connect errors to match NIO behaviour.
+                            if (e.expectedErr() == Errors.ERROR_ECONNREFUSED_NEGATIVE) {
+                                PortUnreachableException error = new PortUnreachableException(e.getMessage());
+                                error.initCause(e);
+                                throw error;
+                            }
+                            throw e;
+                        }
+                        if (allocHandle.lastBytesRead() <= 0) {
+                            // nothing was read, release the buffer.
+                            byteBuf.release();
+                            byteBuf = null;
+                            break;
+                        }
+
+                        final int version = byteBuf.getUnsignedByte(0) >> 4;
+                        if (version == 4) {
+                            packet = new Tun4Packet(byteBuf);
+                        } else if (version == 6) {
+                            packet = new Tun6Packet(byteBuf);
+                        } else {
+                            throw new IOException("Unknown internet protocol: " + version);
+                        }
+
+                        allocHandle.incMessagesRead(1);
+
+                        readPending = false;
+                        pipeline.fireChannelRead(packet);
+
+                        byteBuf = null;
+
+                        // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+                        // as we read anything).
+                    } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
+                } catch (Throwable t) {
+                    if (byteBuf != null) {
+                        byteBuf.release();
+                    }
+                    exception = t;
+                }
+
+                allocHandle.readComplete();
+                pipeline.fireChannelReadComplete();
+
+                if (exception != null) {
+                    pipeline.fireExceptionCaught(exception);
+                }
+            } finally {
+                epollInFinally(config);
+            }
+        }
+    }
+}

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannelConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.socket.TunChannelConfig;
+
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+
+/**
+ * A {@link ChannelConfig} for a {@link EpollTunChannel}.
+ */
+public class EpollTunChannelConfig extends EpollChannelConfig implements TunChannelConfig {
+    private int mtu;
+
+    EpollTunChannelConfig(AbstractEpollChannel channel) {
+        super(channel, new FixedRecvByteBufAllocator(2048));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == TUN_MTU) {
+            return (T) Integer.valueOf(getMtu());
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        if (!super.setOption(option, value)) {
+            if (option == TUN_MTU) {
+                setMtu((Integer) value);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int getMtu() {
+        return mtu;
+    }
+
+    @Override
+    public TunChannelConfig setMtu(int mtu) {
+        if (mtu < 0) {
+            throw new IllegalArgumentException("mtu must be non-negative.");
+        }
+        this.mtu = mtu;
+        return this;
+    }
+}

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannelConfig.java
@@ -19,14 +19,32 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.socket.TunChannelConfig;
+import io.netty.channel.socket.TunChannelOption;
 
+import static io.netty.channel.epoll.EpollTunChannelOption.IFF_MULTI_QUEUE;
 import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
 
 /**
  * A {@link ChannelConfig} for a {@link EpollTunChannel}.
+ *
+ * <h3>Available options</h3>
+ * <p>
+ * In addition to the options provided by {@link ChannelConfig}, {@link TunChannelConfig} allows the
+ * following options in the option map:
+ *
+ * <table border="1" cellspacing="0" cellpadding="6">
+ * <tr>
+ * <th>Name</th><th>Associated setter method</th>
+ * </tr><tr>
+ * <td>{@link EpollTunChannelOption#TUN_MTU}</td><td>{@link #setMtu(int)}</td>
+ * </tr><tr>
+ * <td>{@link EpollTunChannelOption#IFF_MULTI_QUEUE}</td><td>{@link #setMultiqueue(boolean)}</td>
+ * </tr>
+ * </table>
  */
 public class EpollTunChannelConfig extends EpollChannelConfig implements TunChannelConfig {
     private int mtu;
+    private boolean multiqueue;
 
     EpollTunChannelConfig(AbstractEpollChannel channel) {
         super(channel, new FixedRecvByteBufAllocator(2048));
@@ -38,6 +56,9 @@ public class EpollTunChannelConfig extends EpollChannelConfig implements TunChan
         if (option == TUN_MTU) {
             return (T) Integer.valueOf(getMtu());
         }
+        if (option == IFF_MULTI_QUEUE) {
+            return (T) Boolean.valueOf(isMultiqueue());
+        }
         return super.getOption(option);
     }
 
@@ -46,6 +67,8 @@ public class EpollTunChannelConfig extends EpollChannelConfig implements TunChan
         if (!super.setOption(option, value)) {
             if (option == TUN_MTU) {
                 setMtu((Integer) value);
+            } else if (option == IFF_MULTI_QUEUE) {
+                setMultiqueue((Boolean) value);
             } else {
                 return false;
             }
@@ -64,6 +87,15 @@ public class EpollTunChannelConfig extends EpollChannelConfig implements TunChan
             throw new IllegalArgumentException("mtu must be non-negative.");
         }
         this.mtu = mtu;
+        return this;
+    }
+
+    public boolean isMultiqueue() {
+        return multiqueue;
+    }
+
+    public TunChannelConfig setMultiqueue(boolean multiqueue) {
+        this.multiqueue = multiqueue;
         return this;
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannelOption.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollTunChannelOption.java
@@ -13,25 +13,20 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel.socket;
+package io.netty.channel.epoll;
 
 import io.netty.channel.ChannelOption;
+import io.netty.channel.socket.TunChannelOption;
 
 /**
- * Provides {@link ChannelOption}s for {@link TunChannel}s.
+ * Provides {@link ChannelOption}s for {@link EpollTunChannel}s.
  */
-public class TunChannelOption<T> extends ChannelOption<T> {
+public final class EpollTunChannelOption<T> extends TunChannelOption<T> {
     /**
-     * Defines MTU for the created tun device.
+     * Enables/Disables the IFF_MULTI_QUEUE flag.
      * <p>
-     * Increasing the MTU may also require you to adjust {@link #RCVBUF_ALLOCATOR}.
-     * It is necessary, that the {@link #RCVBUF_ALLOCATOR} always yields buffers that can hold a complete IP packet.
-     * <p>
-     * If kqueue is used, buffers capacity must be at least 4 bytes greater than the MTU.
+     * If enabled, multiple {@link EpollTunChannel}s can be assigned to the same device to parallelize
+     * packet sending or receiving.
      */
-    public static final ChannelOption<Integer> TUN_MTU = valueOf("TUN_MTU");
-
-    protected TunChannelOption() {
-        super(null);
-    }
+    public static final ChannelOption<Boolean> IFF_MULTI_QUEUE = valueOf("IFF_MULTI_QUEUE");
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -387,7 +387,7 @@ public final class LinuxSocket extends Socket {
         return new LinuxSocket(res, false);
     }
 
-    public TunAddress bindTun(final SocketAddress socketAddress) throws IOException {
+    public TunAddress bindTun(SocketAddress socketAddress, boolean multiqueue) throws IOException {
         if (socketAddress instanceof TunAddress) {
             TunAddress addr = (TunAddress) socketAddress;
 
@@ -396,7 +396,7 @@ public final class LinuxSocket extends Socket {
                 throw TUN_ILLEGAL_NAME_EXCEPTION;
             }
 
-            String name = bindTun(intValue(), addr.ifName());
+            String name = bindTun(intValue(), addr.ifName(), multiqueue);
             if (name == null) {
                 throw new IOException("bind(...) failed");
             }
@@ -474,7 +474,7 @@ public final class LinuxSocket extends Socket {
     private static native void setUdpGro(int fd, int gro) throws IOException;
 
     private static native int newSocketTunFd();
-    public static native String bindTun(int fd, String name);
+    public static native String bindTun(int fd, String name, boolean multiqueue);
     private static native int getMtu0(String name);
     private static native int setMtu0(String name, int mtu);
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -17,6 +17,7 @@ package io.netty.channel.epoll;
 
 import io.netty.channel.ChannelException;
 import io.netty.channel.DefaultFileRegion;
+import io.netty.channel.socket.TunAddress;
 import io.netty.channel.unix.NativeInetAddress;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
@@ -29,10 +30,13 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Inet6Address;
 import java.net.NetworkInterface;
+import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 
 import static io.netty.channel.unix.Errors.ioResult;
+import static io.netty.channel.unix.Errors.newIOException;
+import static io.netty.util.CharsetUtil.US_ASCII;
 
 /**
  * A socket which provides access Linux native methods.
@@ -40,11 +44,19 @@ import static io.netty.channel.unix.Errors.ioResult;
 @UnstableApi
 public final class LinuxSocket extends Socket {
     static final InetAddress INET6_ANY = unsafeInetAddrByName("::");
+    static final int IFNAMSIZ = 16; // net/if.h
+    private static final IllegalArgumentException TUN_ILLEGAL_NAME_EXCEPTION =
+            new IllegalArgumentException("Device name must be an ASCII string shorter than " +
+                    IFNAMSIZ + " characters or null.");
     private static final InetAddress INET_ANY = unsafeInetAddrByName("0.0.0.0");
     private static final long MAX_UINT32_T = 0xFFFFFFFFL;
 
     LinuxSocket(int fd) {
         super(fd);
+    }
+
+    LinuxSocket(int fd, boolean ipv6) {
+        super(fd, ipv6);
     }
 
     InternetProtocolFamily family() {
@@ -367,6 +379,49 @@ public final class LinuxSocket extends Socket {
         }
     }
 
+    public static LinuxSocket newSocketTun() {
+        int res = newSocketTunFd();
+        if (res < 0) {
+            throw new ChannelException(newIOException("newSocketTun", res));
+        }
+        return new LinuxSocket(res, false);
+    }
+
+    public TunAddress bindTun(final SocketAddress socketAddress) throws IOException {
+        if (socketAddress instanceof TunAddress) {
+            TunAddress addr = (TunAddress) socketAddress;
+
+            if (addr.ifName() != null && (addr.ifName().length() >= IFNAMSIZ ||
+                    !US_ASCII.newEncoder().canEncode(addr.ifName()))) {
+                throw TUN_ILLEGAL_NAME_EXCEPTION;
+            }
+
+            String name = bindTun(intValue(), addr.ifName());
+            if (name == null) {
+                throw new IOException("bind(...) failed");
+            }
+
+            return new TunAddress(name);
+        } else {
+            throw new Error("Unexpected SocketAddress implementation " + socketAddress);
+        }
+    }
+
+    public static int getMtu(String name) throws IOException {
+        int res = getMtu0(name);
+        if (res < 0) {
+            throw newIOException("getMtu", res);
+        }
+        return res;
+    }
+
+    public static void setMtu(String name, int mtu) throws IOException {
+        int res = setMtu0(name, mtu);
+        if (res < 0) {
+            throw newIOException("setMtu", res);
+        }
+    }
+
     private static native void joinGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
                                          int scopeId, int interfaceIndex) throws IOException;
     private static native void joinSsmGroup(int fd, boolean ipv6, byte[] group, byte[] interfaceAddress,
@@ -417,4 +472,9 @@ public final class LinuxSocket extends Socket {
     private static native void setTimeToLive(int fd, int ttl) throws IOException;
     private static native int isUdpGro(int fd) throws IOException;
     private static native void setUdpGro(int fd, int gro) throws IOException;
+
+    private static native int newSocketTunFd();
+    public static native String bindTun(int fd, String name);
+    private static native int getMtu0(String name);
+    private static native int setMtu0(String name, int mtu);
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -387,7 +387,7 @@ public final class LinuxSocket extends Socket {
         return new LinuxSocket(res, false);
     }
 
-    public TunAddress bindTun(SocketAddress socketAddress, boolean multiqueue) throws IOException {
+    public TunAddress bindTun(SocketAddress socketAddress, boolean multiQueue) throws IOException {
         if (socketAddress instanceof TunAddress) {
             TunAddress addr = (TunAddress) socketAddress;
 
@@ -396,7 +396,7 @@ public final class LinuxSocket extends Socket {
                 throw TUN_ILLEGAL_NAME_EXCEPTION;
             }
 
-            String name = bindTun(intValue(), addr.ifName(), multiqueue);
+            String name = bindTun(intValue(), addr.ifName(), multiQueue);
             if (name == null) {
                 throw new IOException("bind(...) failed");
             }
@@ -474,7 +474,7 @@ public final class LinuxSocket extends Socket {
     private static native void setUdpGro(int fd, int gro) throws IOException;
 
     private static native int newSocketTunFd();
-    public static native String bindTun(int fd, String name, boolean multiqueue);
+    public static native String bindTun(int fd, String name, boolean multiQueue);
     private static native int getMtu0(String name);
     private static native int setMtu0(String name, int mtu);
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -36,6 +36,7 @@ import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.epolle
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.epollin;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.epollout;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.epollrdhup;
+import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.isSupportingMultiQueue;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.isSupportingRecvmmsg;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.isSupportingSendmmsg;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.kernelVersion;
@@ -115,6 +116,7 @@ public final class Native {
     private static final int TFO_ENABLED_CLIENT_MASK = 0x1;
     private static final int TFO_ENABLED_SERVER_MASK = 0x2;
     private static final int TCP_FASTOPEN_MODE = tcpFastopenMode();
+    public static final boolean IS_SUPPORTING_MULTI_QUEUE = isSupportingMultiQueue();
     /**
      * <a href ="https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt">tcp_fastopen</a> client mode enabled
      * state.

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
@@ -43,4 +43,5 @@ final class NativeStaticallyReferencedJniMethods {
     static native boolean isSupportingRecvmmsg();
     static native int tcpFastopenMode();
     static native String kernelVersion();
+    static native boolean isSupportingMultiQueue();
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -71,7 +71,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     boolean readReadyRunnablePending;
     boolean inputClosedSeenErrorOnRead;
     protected volatile boolean active;
-    private volatile SocketAddress local;
+    protected volatile SocketAddress local;
     private volatile SocketAddress remote;
 
     AbstractKQueueChannel(Channel parent, BsdSocket fd, boolean active) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueMessageChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueMessageChannel.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOutboundBuffer;
+
+import java.io.IOException;
+
+abstract class AbstractKQueueMessageChannel extends AbstractKQueueChannel {
+
+    private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+
+    AbstractKQueueMessageChannel(Channel parent, BsdSocket fd, boolean active) {
+        super(parent, fd, active);
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return METADATA;
+    }
+
+    protected abstract boolean doWriteMessage(Object msg) throws Exception;
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+        int maxMessagesPerWrite = maxMessagesPerWrite();
+        while (maxMessagesPerWrite > 0) {
+            Object msg = in.current();
+            if (msg == null) {
+                break;
+            }
+
+            try {
+                boolean done = false;
+                for (int i = config().getWriteSpinCount(); i > 0; --i) {
+                    if (doWriteMessage(msg)) {
+                        done = true;
+                        break;
+                    }
+                }
+
+                if (done) {
+                    in.remove();
+                    maxMessagesPerWrite--;
+                } else {
+                    break;
+                }
+            } catch (IOException e) {
+                maxMessagesPerWrite--;
+
+                // Continue on write error as a DatagramChannel can write to multiple remote peers
+                //
+                // See https://github.com/netty/netty/issues/2665
+                in.remove(e);
+            }
+        }
+
+        // Whether all messages were written or not.
+        writeFilter(!in.isEmpty());
+    }
+}

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -44,7 +44,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 final class BsdSocket extends Socket {
     private static final String TUN_DEVICE_PREFIX = "utun";
     private static final IllegalArgumentException TUN_ILLEGAL_NAME_EXCEPTION =
-            new IllegalArgumentException("Device name must be 'utun<index>' or null.");
+            new IllegalArgumentException("Tun name must be 'utun<number>' or null.");
 
     // These limits are just based on observations. I couldn't find anything in header files which formally
     // define these limits.
@@ -279,12 +279,12 @@ final class BsdSocket extends Socket {
         if (socketAddress instanceof TunAddress) {
             TunAddress addr = (TunAddress) socketAddress;
 
-            // TUN devices on BSD systems must be named "utunN" were only N is passed to the OS
-            final int index;
+            // TUN devices on BSD systems must be named "utun<number>" were only <number> is passed to the OS
+            final int number;
             if (addr.ifName() != null) {
                 if (addr.ifName().startsWith(TUN_DEVICE_PREFIX)) {
                     try {
-                        index = Integer.parseInt(addr.ifName().substring(TUN_DEVICE_PREFIX.length()));
+                        number = Integer.parseInt(addr.ifName().substring(TUN_DEVICE_PREFIX.length()));
                     } catch (final NumberFormatException e) {
                         throw TUN_ILLEGAL_NAME_EXCEPTION;
                     }
@@ -292,9 +292,9 @@ final class BsdSocket extends Socket {
                     throw TUN_ILLEGAL_NAME_EXCEPTION;
                 }
             } else {
-                index = 0;
+                number = 0;
             }
-            int res = bindTun(intValue(), index);
+            int res = bindTun(intValue(), number);
             if (res < 0) {
                 throw newIOException("bind", res);
             }
@@ -303,7 +303,7 @@ final class BsdSocket extends Socket {
         }
     }
 
-    public static native int bindTun(int fd, int index);
+    public static native int bindTun(int fd, int number);
 
     public SocketAddress localAddressTun() {
         return new TunAddress(localAddressTun(intValue()));

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -15,8 +15,11 @@
  */
 package io.netty.channel.kqueue;
 
+import io.netty.channel.ChannelException;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.channel.socket.TunAddress;
+import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
@@ -25,11 +28,13 @@ import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 import static io.netty.channel.kqueue.AcceptFilter.PLATFORM_UNSUPPORTED;
 import static io.netty.channel.kqueue.Native.CONNECT_TCP_FASTOPEN;
 import static io.netty.channel.unix.Errors.ERRNO_EINPROGRESS_NEGATIVE;
 import static io.netty.channel.unix.Errors.ioResult;
+import static io.netty.channel.unix.Errors.newIOException;
 import static io.netty.channel.unix.NativeInetAddress.ipv4MappedIpv6Address;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -37,6 +42,9 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * A socket which provides access BSD native methods.
  */
 final class BsdSocket extends Socket {
+    private static final String TUN_DEVICE_PREFIX = "utun";
+    private static final IllegalArgumentException TUN_ILLEGAL_NAME_EXCEPTION =
+            new IllegalArgumentException("Device name must be 'utun<index>' or null.");
 
     // These limits are just based on observations. I couldn't find anything in header files which formally
     // define these limits.
@@ -52,6 +60,10 @@ final class BsdSocket extends Socket {
 
     BsdSocket(int fd) {
         super(fd);
+    }
+
+    BsdSocket(int fd, boolean ipv6) {
+        super(fd, ipv6);
     }
 
     void setAcceptFilter(AcceptFilter acceptFilter) throws IOException {
@@ -252,4 +264,69 @@ final class BsdSocket extends Socket {
     private static native void setSndLowAt(int fd, int lowAt) throws IOException;
 
     private static native void setTcpFastOpen(int fd, int enableFastOpen) throws IOException;
+
+    public static BsdSocket newSocketTun() {
+        int res = newSocketTunFd();
+        if (res < 0) {
+            throw new ChannelException(newIOException("newSocketTun", res));
+        }
+        return new BsdSocket(res, false);
+    }
+
+    private static native int newSocketTunFd();
+
+    public void bindTun(final SocketAddress socketAddress) throws IOException {
+        if (socketAddress instanceof TunAddress) {
+            TunAddress addr = (TunAddress) socketAddress;
+
+            // TUN devices on BSD systems must be named "utunN" were only N is passed to the OS
+            final int index;
+            if (addr.ifName() != null) {
+                if (addr.ifName().startsWith(TUN_DEVICE_PREFIX)) {
+                    try {
+                        index = Integer.parseInt(addr.ifName().substring(TUN_DEVICE_PREFIX.length()));
+                    } catch (final NumberFormatException e) {
+                        throw TUN_ILLEGAL_NAME_EXCEPTION;
+                    }
+                } else {
+                    throw TUN_ILLEGAL_NAME_EXCEPTION;
+                }
+            } else {
+                index = 0;
+            }
+            int res = bindTun(intValue(), index);
+            if (res < 0) {
+                throw newIOException("bind", res);
+            }
+        } else {
+            throw new Error("Unexpected SocketAddress implementation " + socketAddress);
+        }
+    }
+
+    public static native int bindTun(int fd, int index);
+
+    public SocketAddress localAddressTun() {
+        return new TunAddress(localAddressTun(intValue()));
+    }
+
+    public static native String localAddressTun(int fd);
+
+    public int getMtu(final String name) throws IOException {
+        int res = getMtu(intValue(), name);
+        if (res < 0) {
+            throw newIOException("getMtu", res);
+        }
+        return res;
+    }
+
+    private static native int getMtu(int fd, String name);
+
+    public void setMtu(final String name, final int mtu) throws IOException {
+        int res = setMtu(intValue(), name, mtu);
+        if (res < 0) {
+            throw newIOException("setMtu", res);
+        }
+    }
+
+    private static native int setMtu(int fd, String name, int mtu);
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -292,7 +292,8 @@ final class BsdSocket extends Socket {
                     throw TUN_ILLEGAL_NAME_EXCEPTION;
                 }
             } else {
-                number = 0;
+                // let platform pick device name
+                number = -1;
             }
             int res = bindTun(intValue(), number);
             if (res < 0) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueTunChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueTunChannel.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.Tun4Packet;
+import io.netty.channel.socket.Tun6Packet;
+import io.netty.channel.socket.TunAddress;
+import io.netty.channel.socket.TunChannel;
+import io.netty.channel.socket.TunPacket;
+import io.netty.channel.unix.Errors;
+import io.netty.channel.unix.IovArray;
+import io.netty.channel.unix.UnixChannelUtil;
+import io.netty.util.UncheckedBooleanSupplier;
+import io.netty.util.internal.StringUtil;
+
+import java.io.IOException;
+import java.net.PortUnreachableException;
+import java.net.SocketAddress;
+
+import static io.netty.channel.kqueue.BsdSocket.newSocketTun;
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+
+/**
+ * {@link DatagramChannel} implementation that uses linux kqueue edge-triggered mode for
+ * maximal performance.
+ */
+public class KQueueTunChannel extends AbstractKQueueMessageChannel implements TunChannel {
+    private static final String EXPECTED_TYPES =
+            " (expected: " + StringUtil.simpleClassName(TunPacket.class) + ", " +
+                    StringUtil.simpleClassName(ByteBuf.class) + ')';
+    static final int AF_INET = 2; // sys/socket.h
+    static final int AF_INET6 = 30; // sys/socket.h
+    static final int AF_HEADER_LENGTH = 4; // int32
+    private final KQueueTunChannelConfig config;
+
+    public KQueueTunChannel() {
+        super(null, newSocketTun(), false);
+        this.config = new KQueueTunChannelConfig(this);
+    }
+
+    @Override
+    protected boolean doWriteMessage(final Object msg) throws Exception {
+        ByteBuf data;
+        int addressFamily;
+        if (msg instanceof Tun4Packet) {
+            TunPacket packet = (Tun4Packet) msg;
+            data = packet.content();
+            addressFamily = AF_INET;
+        } else if (msg instanceof Tun6Packet) {
+            TunPacket packet = (Tun6Packet) msg;
+            data = packet.content();
+            addressFamily = AF_INET6;
+        } else {
+            data = (ByteBuf) msg;
+            addressFamily = data.getUnsignedByte(0) >> 4 == 4 ? AF_INET : AF_INET6;
+        }
+
+        final int dataLen = data.readableBytes();
+        if (dataLen == 0) {
+            return true;
+        }
+
+        // add address family header
+        ByteBuf familyHeader = alloc().directBuffer(AF_HEADER_LENGTH).writeInt(addressFamily);
+        data = alloc().compositeDirectBuffer(2).addComponents(true, familyHeader, data.retain());
+
+        try {
+            IovArray array = ((KQueueEventLoop) eventLoop()).cleanArray();
+            array.add(data, data.readerIndex(), data.readableBytes());
+            int cnt = array.count();
+            assert cnt != 0;
+
+            final long writtenBytes = socket.writevAddresses(array.memoryAddress(0), cnt);
+            return writtenBytes > 0;
+        } finally {
+            data.release();
+        }
+    }
+
+    @Override
+    protected Object filterOutboundMessage(final Object msg) {
+        if (msg instanceof Tun4Packet) {
+            Tun4Packet packet = (Tun4Packet) msg;
+            ByteBuf content = packet.content();
+            return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
+                    new Tun4Packet(newDirectBuffer(packet, content)) : msg;
+        }
+
+        if (msg instanceof Tun6Packet) {
+            Tun6Packet packet = (Tun6Packet) msg;
+            ByteBuf content = packet.content();
+            return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
+                    new Tun6Packet(newDirectBuffer(packet, content)) : msg;
+        }
+
+        if (msg instanceof ByteBuf) {
+            ByteBuf buf = (ByteBuf) msg;
+            return UnixChannelUtil.isBufferCopyNeededForWrite(buf) ? newDirectBuffer(buf) : buf;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
+    }
+
+    @Override
+    public KQueueChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public TunAddress localAddress() {
+        return (TunAddress) super.localAddress();
+    }
+
+    @Override
+    public int mtu() throws IOException {
+        return socket.getMtu(((TunAddress) this.local).ifName());
+    }
+
+    @Override
+    protected AbstractKQueueUnsafe newUnsafe() {
+        return new KQueueTunChannelUnsafe();
+    }
+
+    @Override
+    protected void doBind(SocketAddress local) throws Exception {
+        socket.bindTun(local);
+        this.local = socket.localAddressTun();
+        active = true;
+
+        final int mtu = config.getOption(TUN_MTU);
+        if (mtu > 0) {
+            socket.setMtu(((TunAddress) this.local).ifName(), mtu);
+        }
+    }
+
+    final class KQueueTunChannelUnsafe extends AbstractKQueueUnsafe {
+        @Override
+        void readReady(final KQueueRecvByteAllocatorHandle allocHandle) {
+            assert eventLoop().inEventLoop();
+            final KQueueChannelConfig config = config();
+            if (shouldBreakReadReady(config)) {
+                clearReadFilter0();
+                return;
+            }
+            final ChannelPipeline pipeline = pipeline();
+            final ByteBufAllocator allocator = config.getAllocator();
+            allocHandle.reset(config);
+            readReadyBefore();
+
+            Throwable exception = null;
+            try {
+                ByteBuf byteBuf = null;
+                try {
+                    do {
+                        byteBuf = allocHandle.allocate(allocator);
+                        allocHandle.attemptedBytesRead(byteBuf.writableBytes());
+
+                        final TunPacket packet;
+                        try {
+                            allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                        } catch (Errors.NativeIoException e) {
+                            // We need to correctly translate connect errors to match NIO behaviour.
+                            if (e.expectedErr() == Errors.ERROR_ECONNREFUSED_NEGATIVE) {
+                                PortUnreachableException error = new PortUnreachableException(e.getMessage());
+                                error.initCause(e);
+                                throw error;
+                            }
+                            throw e;
+                        }
+                        if (allocHandle.lastBytesRead() <= 0) {
+                            // nothing was read, release the buffer.
+                            byteBuf.release();
+                            byteBuf = null;
+                            break;
+                        }
+
+                        final int addressFamily = byteBuf.readInt();
+
+                        // remove address family header
+                        byteBuf = byteBuf.slice(AF_HEADER_LENGTH, byteBuf.capacity() - AF_HEADER_LENGTH)
+                                .writerIndex(byteBuf.readableBytes());
+
+                        if (addressFamily == AF_INET) {
+                            packet = new Tun4Packet(byteBuf);
+                        } else if (addressFamily == AF_INET6) {
+                            packet = new Tun6Packet(byteBuf);
+                        } else {
+                            throw new IOException("Unknown internet protocol: " + addressFamily);
+                        }
+
+                        allocHandle.incMessagesRead(1);
+
+                        readPending = false;
+                        pipeline.fireChannelRead(packet);
+
+                        byteBuf = null;
+
+                        // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+                        // as we read anything).
+                    } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
+                } catch (Throwable t) {
+                    if (byteBuf != null) {
+                        byteBuf.release();
+                    }
+                    exception = t;
+                }
+
+                allocHandle.readComplete();
+                pipeline.fireChannelReadComplete();
+
+                if (exception != null) {
+                    pipeline.fireExceptionCaught(exception);
+                }
+            } finally {
+                readReadyFinally(config);
+            }
+        }
+    }
+}

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueTunChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueTunChannelConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.socket.TunChannelConfig;
+
+import static io.netty.channel.kqueue.KQueueTunChannel.AF_HEADER_LENGTH;
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+
+/**
+ * A {@link ChannelConfig} for a {@link KQueueTunChannel}.
+ */
+public class KQueueTunChannelConfig extends KQueueChannelConfig implements TunChannelConfig {
+    private int mtu;
+
+    KQueueTunChannelConfig(final AbstractKQueueChannel channel) {
+        super(channel, new FixedRecvByteBufAllocator(2048 + AF_HEADER_LENGTH));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(final ChannelOption<T> option) {
+        if (option == TUN_MTU) {
+            return (T) Integer.valueOf(getMtu());
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        if (!super.setOption(option, value)) {
+            if (option == TUN_MTU) {
+                setMtu((Integer) value);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int getMtu() {
+        return mtu;
+    }
+
+    @Override
+    public TunChannelConfig setMtu(final int mtu) {
+        if (mtu < 0) {
+            throw new IllegalArgumentException("mtu must be non-negative.");
+        }
+        this.mtu = mtu;
+        return this;
+    }
+}

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -22,6 +22,7 @@
 #define _GNU_SOURCE
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <netinet/in.h>
@@ -638,7 +639,7 @@ static jint netty_epoll_linuxsocket_openTunFd(JNIEnv* env) {
     return open("/dev/net/tun", O_RDWR | O_NONBLOCK);
 }
 
-static jstring netty_epoll_linuxsocket_bindTun(JNIEnv* env, jclass clazz, jint fd, jstring name) {
+static jstring netty_epoll_linuxsocket_bindTun(JNIEnv* env, jclass clazz, jint fd, jstring name, jboolean multiqueue) {
     // mark as tun device
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
@@ -647,6 +648,9 @@ static jstring netty_epoll_linuxsocket_bindTun(JNIEnv* env, jclass clazz, jint f
         const char* f_name = (*env)->GetStringUTFChars(env, name, 0);
         strncpy(ifr.ifr_name, f_name, IFNAMSIZ);
         (*env)->ReleaseStringUTFChars(env, name, f_name);
+    }
+    if (multiqueue) {
+        ifr.ifr_flags |= IFF_MULTI_QUEUE;
     }
 
     if (ioctl(fd, TUNSETIFF, &ifr) == -1) {
@@ -766,7 +770,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "isUdpGro", "(I)I", (void *) netty_epoll_linuxsocket_isUdpGro },
   { "setUdpGro", "(II)V", (void *) netty_epoll_linuxsocket_setUdpGro },
   { "newSocketTunFd", "()I", (void *) netty_epoll_linuxsocket_openTunFd },
-  { "bindTun", "(ILjava/lang/String;)Ljava/lang/String;", (void *) netty_epoll_linuxsocket_bindTun },
+  { "bindTun", "(ILjava/lang/String;Z)Ljava/lang/String;", (void *) netty_epoll_linuxsocket_bindTun },
   { "getMtu0", "(Ljava/lang/String;)I", (void *) netty_epoll_linuxsocket_getMtu },
   { "setMtu0", "(Ljava/lang/String;I)I", (void *) netty_epoll_linuxsocket_setMtu }
 

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -650,7 +650,12 @@ static jstring netty_epoll_linuxsocket_bindTun(JNIEnv* env, jclass clazz, jint f
         (*env)->ReleaseStringUTFChars(env, name, f_name);
     }
     if (multiqueue) {
+#if defined(IFF_MULTI_QUEUE)
         ifr.ifr_flags |= IFF_MULTI_QUEUE;
+#else
+        // not available on CentOS 6
+        netty_unix_errors_throwIOException(env, "netty-transport-native-epoll was built on a platform that does not support IFF_MULTI_QUEUE");
+#endif
     }
 
     if (ioctl(fd, TUNSETIFF, &ifr) == -1) {

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -36,6 +36,7 @@
 #include <inttypes.h>
 #include <link.h>
 #include <time.h>
+#include <linux/if_tun.h>
 // Needed to be able to use syscalls directly and so not depend on newer GLIBC versions
 #include <linux/net.h>
 #include <sys/syscall.h>
@@ -549,6 +550,14 @@ static jint netty_epoll_native_recvmmsg0(JNIEnv* env, jclass clazz, jint fd, jbo
     return (jint) res;
 }
 
+static jboolean netty_epoll_native_isSupportingMultiQueue(JNIEnv* env, jclass clazz) {
+#if defined(IFF_MULTI_QUEUE)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
+}
+
 static jstring netty_epoll_native_kernelVersion(JNIEnv* env, jclass clazz) {
     struct utsname name;
 
@@ -678,7 +687,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "isSupportingSendmmsg", "()Z", (void *) netty_epoll_native_isSupportingSendmmsg },
   { "isSupportingRecvmmsg", "()Z", (void *) netty_epoll_native_isSupportingRecvmmsg },
   { "tcpFastopenMode", "()I", (void *) netty_epoll_native_tcpFastopenMode },
-  { "kernelVersion", "()Ljava/lang/String;", (void *) netty_epoll_native_kernelVersion }
+  { "kernelVersion", "()Ljava/lang/String;", (void *) netty_epoll_native_kernelVersion },
+  { "isSupportingMultiQueue", "()Z", (void *) netty_epoll_native_isSupportingMultiQueue }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTunChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTunChannelConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.netty.channel.epoll.EpollTunChannelOption.IFF_MULTI_QUEUE;
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EpollTunChannelConfigTest {
+    @BeforeAll
+    public static void loadJNI() {
+        Epoll.ensureAvailability();
+    }
+
+    @Test
+    public void testSetGetMtu() throws IOException {
+        EpollTunChannel channel = null;
+        try {
+            channel = new EpollTunChannel();
+            final EpollChannelConfig config = channel.config();
+
+            assertEquals(0, config.getOption(TUN_MTU));
+
+            config.setOption(TUN_MTU, 1500);
+            assertEquals(1500, config.getOption(TUN_MTU));
+        } finally {
+            if (channel != null) {
+                channel.socket.close();
+            }
+        }
+    }
+
+    @Test
+    public void testSetGetMultiQueue() throws IOException {
+        EpollTunChannel channel = null;
+        try {
+            channel = new EpollTunChannel();
+            final EpollChannelConfig config = channel.config();
+
+            assertFalse(config.getOption(IFF_MULTI_QUEUE));
+
+            config.setOption(IFF_MULTI_QUEUE, true);
+            assertTrue(config.getOption(IFF_MULTI_QUEUE));
+        } finally {
+            if (channel != null) {
+                channel.socket.close();
+            }
+        }
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTunChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTunChannelTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.testsuite.transport.socket.TunChannelTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+
+public class EpollTunChannelTest extends TunChannelTest {
+    @BeforeAll
+    public static void loadJNI() {
+        Epoll.ensureAvailability();
+    }
+
+    public EpollTunChannelTest() {
+        super(new EpollEventLoopGroup(1), EpollTunChannel.class, EpollDatagramChannel.class);
+    }
+
+    @Override
+    protected void attachAddressAndNetmask(String name,
+                                           String address,
+                                           int netmask) throws IOException {
+        exec("/sbin/ip", "-4", "addr", "add", address + '/' + netmask, "dev", name);
+        exec("/sbin/ip", "link", "set", "dev", name, "up");
+    }
+}

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -161,7 +161,7 @@ static jint netty_kqueue_bsdsocket_newSocketTunFd(JNIEnv* env, jclass clazz) {
 #endif
 }
 
-static jint netty_kqueue_bsdsocket_bindTun(JNIEnv* env, jclass clazz, jint fd, jint index) {
+static jint netty_kqueue_bsdsocket_bindTun(JNIEnv* env, jclass clazz, jint fd, jint number) {
     // mark as tun device
     struct ctl_info ctlInfo;
     memset(&ctlInfo, 0, sizeof(ctlInfo));
@@ -180,7 +180,7 @@ static jint netty_kqueue_bsdsocket_bindTun(JNIEnv* env, jclass clazz, jint fd, j
     address.sc_len = sizeof(address);
     address.sc_family = AF_SYSTEM;
     address.ss_sysaddr = AF_SYS_CONTROL;
-    address.sc_unit = index;
+    address.sc_unit = number + 1; // 1 -> utun0, etc.
     if (connect(fd, (struct sockaddr*) &address, sizeof(address)) == -1) {
         netty_unix_errors_throwIOException(env, "connect() failed");
         return -1;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -25,6 +25,13 @@
 #include <sys/ucred.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/kern_control.h>
+#include <sys/sockio.h>
+#include <sys/sys_domain.h>
+#include <net/if.h>
+#include <net/if_utun.h>
 
 #include "netty_kqueue_bsdsocket.h"
 #include "netty_unix_errors.h"
@@ -136,6 +143,84 @@ static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env, jclass clazz,
 #else
     return -ENOSYS;
 #endif
+}
+
+static jint netty_kqueue_bsdsocket_newSocketTunFd(JNIEnv* env, jclass clazz) {
+#ifdef SOCK_NONBLOCK
+    return socket(AF_SYSTEM, SOCK_DGRAM | SOCK_NONBLOCK, SYSPROTO_CONTROL);
+#else
+    int socketFd = socket(AF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
+    int flags;
+    // Don't initialize flags until we know the socket is good so errno is preserved.
+    if (socketFd < 0 ||
+        (flags = fcntl(socketFd, F_GETFL, 0)) < 0 ||
+         fcntl(socketFd, F_SETFL, flags | O_NONBLOCK) < 0) {
+      return -1;
+    }
+    return socketFd;
+#endif
+}
+
+static jint netty_kqueue_bsdsocket_bindTun(JNIEnv* env, jclass clazz, jint fd, jint index) {
+    // mark as tun device
+    struct ctl_info ctlInfo;
+    memset(&ctlInfo, 0, sizeof(ctlInfo));
+    if (strlcpy(ctlInfo.ctl_name, UTUN_CONTROL_NAME, sizeof(ctlInfo.ctl_name)) >= sizeof(ctlInfo.ctl_name)) {
+        netty_unix_errors_throwIOException(env, "UTUN_CONTROL_NAME too long");
+        return -1;
+    }
+    if (ioctl(fd, CTLIOCGINFO, &ctlInfo) == -1) {
+        netty_unix_errors_throwIOException(env, "ioctl() failed");
+        return -1;
+    }
+
+    // define address of socket
+    struct sockaddr_ctl address;
+    address.sc_id = ctlInfo.ctl_id;
+    address.sc_len = sizeof(address);
+    address.sc_family = AF_SYSTEM;
+    address.ss_sysaddr = AF_SYS_CONTROL;
+    address.sc_unit = index;
+    if (connect(fd, (struct sockaddr*) &address, sizeof(address)) == -1) {
+        netty_unix_errors_throwIOException(env, "connect() failed");
+        return -1;
+    }
+
+    return 0;
+}
+
+static jstring netty_kqueue_bsdsocket_localAddressTun(JNIEnv* env, jclass clazz, jint fd) {
+    char sockName[IFNAMSIZ];
+    int sockNameLen = IFNAMSIZ;
+    if (getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, sockName, (uint32_t*) &sockNameLen) == -1) {
+        netty_unix_errors_throwIOException(env, "getsockopt() failed");
+        return NULL;
+    }
+
+    return (*env)->NewStringUTF(env, sockName);
+}
+
+static jint netty_kqueue_bsdsocket_getMtu(JNIEnv* env, jclass clazz, jint fd, jstring name) {
+    struct ifreq ifr;
+    const char* f_name = (*env)->GetStringUTFChars(env, name, 0);
+    strncpy(ifr.ifr_name, f_name, IFNAMSIZ);
+    (*env)->ReleaseStringUTFChars(env, name, f_name);
+
+    if (ioctl(fd, SIOCGIFMTU, &ifr) == -1) {
+        return -1;
+    }
+
+    return ifr.ifr_mtu;
+}
+
+static jint netty_kqueue_bsdsocket_setMtu(JNIEnv* env, jclass clazz, jint fd, jstring name, jint mtu) {
+     struct ifreq ifr;
+     const char* f_name = (*env)->GetStringUTFChars(env, name, 0);
+     strncpy(ifr.ifr_name, f_name, IFNAMSIZ);
+     (*env)->ReleaseStringUTFChars(env, name, f_name);
+     ifr.ifr_mtu = mtu;
+
+     return ioctl(fd, SIOCSIFMTU, &ifr);
 }
 
 static void netty_kqueue_bsdsocket_setAcceptFilter(JNIEnv* env, jclass clazz, jint fd, jstring afName, jstring afArg) {
@@ -267,7 +352,12 @@ static const JNINativeMethod fixed_method_table[] = {
   { "getTcpNoPush", "(I)I", (void *) netty_kqueue_bsdsocket_getTcpNoPush },
   { "getSndLowAt", "(I)I", (void *) netty_kqueue_bsdsocket_getSndLowAt },
   { "isTcpFastOpen", "(I)I", (void *) netty_kqueue_bsdsocket_isTcpFastOpen },
-  { "connectx", "(IIZ[BIIZ[BIIIJII)I", (void *) netty_kqueue_bsdsocket_connectx }
+  { "connectx", "(IIZ[BIIZ[BIIIJII)I", (void *) netty_kqueue_bsdsocket_connectx },
+  { "newSocketTunFd", "()I", (void *) netty_kqueue_bsdsocket_newSocketTunFd },
+  { "bindTun", "(II)I", (void *) netty_kqueue_bsdsocket_bindTun },
+  { "localAddressTun", "(I)Ljava/lang/String;", (void *) netty_kqueue_bsdsocket_localAddressTun },
+  { "getMtu", "(ILjava/lang/String;)I", (void *) netty_kqueue_bsdsocket_getMtu },
+  { "setMtu", "(ILjava/lang/String;I)I", (void *) netty_kqueue_bsdsocket_setMtu }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueTunChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueTunChannelConfigTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.netty.channel.socket.TunChannelOption.TUN_MTU;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KQueueTunChannelConfigTest {
+    @BeforeAll
+    public static void loadJNI() {
+        KQueue.ensureAvailability();
+    }
+
+    @Test
+    public void testSetGetMtu() throws IOException {
+        KQueueTunChannel channel = null;
+        try {
+            channel = new KQueueTunChannel();
+            final KQueueChannelConfig config = channel.config();
+
+            assertEquals(0, config.getOption(TUN_MTU));
+
+            config.setOption(TUN_MTU, 1500);
+            assertEquals(1500, config.getOption(TUN_MTU));
+        } finally {
+            if (channel != null) {
+                channel.socket.close();
+            }
+        }
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueTunChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueTunChannelTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.testsuite.transport.socket.TunChannelTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+
+public class KQueueTunChannelTest extends TunChannelTest {
+    @BeforeAll
+    public static void loadJNI() {
+        KQueue.ensureAvailability();
+    }
+
+    public KQueueTunChannelTest() {
+        super(new KQueueEventLoopGroup(1), KQueueTunChannel.class, KQueueDatagramChannel.class);
+    }
+
+    @Override
+    protected void attachAddressAndNetmask(String name,
+                                           String address,
+                                           int netmask) throws IOException {
+        exec("/sbin/ifconfig", name, "add", address, address);
+        exec("/sbin/route", "add", "-net", address + '/' + netmask, "-iface", name);
+    }
+}

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -52,10 +52,15 @@ public class Socket extends FileDescriptor {
 
     protected final boolean ipv6;
 
-    public Socket(int fd) {
+    public Socket(int fd, boolean ipv6) {
         super(fd);
-        ipv6 = isIPv6(fd);
+        this.ipv6 = ipv6;
     }
+
+    public Socket(int fd) {
+        this(fd, isIPv6(fd));
+    }
+
     /**
      * Returns {@code true} if we should use IPv6 internally, {@code false} otherwise.
      */

--- a/transport/src/main/java/io/netty/channel/socket/Tun4Packet.java
+++ b/transport/src/main/java/io/netty/channel/socket/Tun4Packet.java
@@ -21,6 +21,8 @@ import io.netty.util.internal.StringUtil;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 
+import static io.netty.channel.socket.InternetProtocolFamily.IPv4;
+
 /**
  * IPv4-based {@link TunPacket}.
  */
@@ -63,8 +65,8 @@ public class Tun4Packet extends TunPacket {
     }
 
     @Override
-    public int version() {
-        return content().getUnsignedByte(INET4_VERSION_AND_INTERNET_HEADER_LENGTH) >> 4;
+    public InternetProtocolFamily version() {
+        return IPv4;
     }
 
     public int internetHeaderLength() {

--- a/transport/src/main/java/io/netty/channel/socket/Tun4Packet.java
+++ b/transport/src/main/java/io/netty/channel/socket/Tun4Packet.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+
+/**
+ * IPv4-based {@link TunPacket}.
+ */
+@SuppressWarnings("unused")
+public class Tun4Packet extends TunPacket {
+    public static final int INET4_HEADER_LENGTH = 20;
+    // https://datatracker.ietf.org/doc/html/rfc791#section-3.1
+    public static final int INET4_VERSION_AND_INTERNET_HEADER_LENGTH = 0;
+    public static final int INET4_TYPE_OF_SERVICE = 1;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_ROUTINE = 0;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_PRIORITY = 1;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_IMMEDIATE = 2;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_FLASH = 3;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_FLASH_OVERRIDE = 4;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_CRITIC_ECP = 5;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_INTERNETWORK_CONTROL = 6;
+    public static final int INET4_TYPE_OF_SERVICE_PRECEDENCE_NETWORK_CONTROL = 7;
+    public static final int INET4_TYPE_OF_SERVICE_DELAY_MASK = 1 << 3;
+    public static final int INET4_TYPE_OF_SERVICE_THROUGHPUT_MASK = 1 << 4;
+    public static final int INET4_TYPE_OF_SERVICE_RELIBILITY_MASK = 1 << 5;
+    public static final int INET4_TOTAL_LENGTH = 2;
+    public static final int INET4_IDENTIFICATION = 4;
+    public static final int INET4_FLAGS_AND_FRAGMENT_OFFSET = 6;
+    public static final int INET4_FLAGS_DONT_FRAGMENT_MASK = 1 << 1;
+    public static final int INET4_FLAGS_MORE_FRAGMENTS_MASK = 1 << 2;
+    public static final int INET4_TIME_TO_LIVE = 8;
+    public static final int INET4_PROTOCOL = 9;
+    public static final int INET4_HEADER_CHECKSUM = 10;
+    public static final int INET4_SOURCE_ADDRESS = 12;
+    public static final int INET4_DESTINATION_ADDRESS = 16;
+    private Inet4Address sourceAddress;
+    private Inet4Address destinationAddress;
+
+    public Tun4Packet(ByteBuf data) {
+        super(data);
+        if (data.readableBytes() < INET4_HEADER_LENGTH) {
+            throw new IllegalArgumentException("data has only " + data.readableBytes() +
+                    " readable bytes. But an IPv4 packet must be at least " + INET4_HEADER_LENGTH + " bytes long.");
+        }
+    }
+
+    @Override
+    public int version() {
+        return content().getUnsignedByte(INET4_VERSION_AND_INTERNET_HEADER_LENGTH) >> 4;
+    }
+
+    public int internetHeaderLength() {
+        return content().getUnsignedByte(INET4_VERSION_AND_INTERNET_HEADER_LENGTH) & 0x0f;
+    }
+
+    public int typeOfService() {
+        return content().getUnsignedShort(INET4_TYPE_OF_SERVICE);
+    }
+
+    public int totalLength() {
+        return content().getUnsignedShort(INET4_TOTAL_LENGTH);
+    }
+
+    public int identification() {
+        return content().getUnsignedShort(INET4_IDENTIFICATION);
+    }
+
+    public int flags() {
+        return content().getUnsignedByte(INET4_FLAGS_AND_FRAGMENT_OFFSET) >> 5;
+    }
+
+    public int fragmentOffset() {
+        return content().getUnsignedShort(INET4_FLAGS_AND_FRAGMENT_OFFSET) & 0x01fff;
+    }
+
+    public int timeToLive() {
+        return content().getUnsignedByte(INET4_TIME_TO_LIVE);
+    }
+
+    public int protocol() {
+        return content().getUnsignedByte(INET4_PROTOCOL);
+    }
+
+    public int headerChecksum() {
+        return content().getUnsignedShort(INET4_HEADER_CHECKSUM);
+    }
+
+    @Override
+    public Inet4Address sourceAddress() {
+        if (sourceAddress == null) {
+            try {
+                byte[] dst = new byte[4];
+                content().getBytes(INET4_SOURCE_ADDRESS, dst, 0, 4);
+                sourceAddress = (Inet4Address) Inet4Address.getByAddress(dst);
+            } catch (UnknownHostException e) {
+                // unreachable code
+                throw new IllegalStateException();
+            }
+        }
+        return sourceAddress;
+    }
+
+    @Override
+    public Inet4Address destinationAddress() {
+        if (destinationAddress == null) {
+            try {
+                byte[] dst = new byte[4];
+                content().getBytes(INET4_DESTINATION_ADDRESS, dst, 0, 4);
+                destinationAddress = (Inet4Address) Inet4Address.getByAddress(dst);
+            } catch (UnknownHostException e) {
+                // unreachable code
+                throw new IllegalStateException();
+            }
+        }
+        return destinationAddress;
+    }
+
+    /**
+     * Returns the remaining data behind the IP header. Modifying the content of the returned buffer
+     * or this packet's buffer affects each other's content while they maintain separate indexes and
+     * marks.
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the reference count
+     * will NOT be increased.
+     */
+    public ByteBuf data() {
+        return content().slice(INET4_HEADER_LENGTH, content().readableBytes() - INET4_HEADER_LENGTH);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(StringUtil.simpleClassName(this))
+                .append('[')
+                .append("id=").append(identification())
+                .append(", len=").append(totalLength())
+                .append(", src=").append(sourceAddress().getHostAddress())
+                .append(", dst=").append(destinationAddress().getHostAddress())
+                .append(']').toString();
+    }
+
+    public boolean verifyChecksum() {
+        return calculateChecksum(content()) == 0;
+    }
+
+    public static int calculateChecksum(ByteBuf buf) {
+        int sum = 0;
+        for (int i = 0; i < INET4_HEADER_LENGTH; i += 2) {
+            sum += buf.getUnsignedShort(i);
+        }
+        return (~((sum & 0xffff) + (sum >> 16))) & 0xffff;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/socket/Tun6Packet.java
+++ b/transport/src/main/java/io/netty/channel/socket/Tun6Packet.java
@@ -21,6 +21,8 @@ import io.netty.util.internal.StringUtil;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
 
+import static io.netty.channel.socket.InternetProtocolFamily.IPv6;
+
 /**
  * IPv6-based {@link TunPacket}.
  */
@@ -47,8 +49,8 @@ public class Tun6Packet extends TunPacket {
     }
 
     @Override
-    public int version() {
-        return content().getUnsignedByte(INET6_VERSION_AND_TRAFFIC_CLASS) >> 4;
+    public InternetProtocolFamily version() {
+        return IPv6;
     }
 
     public int trafficClass() {

--- a/transport/src/main/java/io/netty/channel/socket/Tun6Packet.java
+++ b/transport/src/main/java/io/netty/channel/socket/Tun6Packet.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+
+import java.net.Inet6Address;
+import java.net.UnknownHostException;
+
+/**
+ * IPv6-based {@link TunPacket}.
+ */
+@SuppressWarnings("unused")
+public class Tun6Packet extends TunPacket {
+    public static final int INET6_HEADER_LENGTH = 40;
+    // https://datatracker.ietf.org/doc/html/rfc8200#section-3
+    public static final int INET6_VERSION_AND_TRAFFIC_CLASS = 0;
+    public static final int INET6_FLOW_LABEL = 1;
+    public static final int INET6_PAYLOAD_LENGTH = 4;
+    public static final int INET6_NEXT_HEADER = 6;
+    public static final int INET6_HOP_LIMIT = 7;
+    public static final int INET6_SOURCE_ADDRESS = 8;
+    public static final int INET6_DESTINATION_ADDRESS = 24;
+    private Inet6Address sourceAddress;
+    private Inet6Address destinationAddress;
+
+    public Tun6Packet(ByteBuf data) {
+        super(data);
+        if (data.readableBytes() < INET6_HEADER_LENGTH) {
+            throw new IllegalArgumentException("data has only " + data.readableBytes() +
+                    " readable bytes. But an IPv6 packet must be at least " + INET6_HEADER_LENGTH + " bytes long.");
+        }
+    }
+
+    @Override
+    public int version() {
+        return content().getUnsignedByte(INET6_VERSION_AND_TRAFFIC_CLASS) >> 4;
+    }
+
+    public int trafficClass() {
+        return content().getUnsignedShort(INET6_VERSION_AND_TRAFFIC_CLASS) >> 4 & 0x0f;
+    }
+
+    public long flowLabel() {
+        return content().getUnsignedInt(INET6_FLOW_LABEL) >> 8 & 0x0fffff;
+    }
+
+    public long payloadLength() {
+        return content().getUnsignedShort(INET6_PAYLOAD_LENGTH);
+    }
+
+    public int nextHeader() {
+        return content().getUnsignedByte(INET6_NEXT_HEADER);
+    }
+
+    public int hopLimit() {
+        return content().getUnsignedByte(INET6_HOP_LIMIT);
+    }
+
+    @Override
+    public Inet6Address sourceAddress() {
+        if (sourceAddress == null) {
+            try {
+                byte[] dst = new byte[16];
+                content().getBytes(INET6_SOURCE_ADDRESS, dst, 0, 16);
+                sourceAddress = (Inet6Address) Inet6Address.getByAddress(dst);
+            } catch (UnknownHostException e) {
+                // unreachable code
+                throw new IllegalStateException();
+            }
+        }
+        return sourceAddress;
+    }
+
+    @Override
+    public Inet6Address destinationAddress() {
+        if (destinationAddress == null) {
+            try {
+                byte[] dst = new byte[16];
+                content().getBytes(INET6_DESTINATION_ADDRESS, dst, 0, 16);
+                destinationAddress = (Inet6Address) Inet6Address.getByAddress(dst);
+            } catch (UnknownHostException e) {
+                // unreachable code
+                throw new IllegalStateException();
+            }
+        }
+        return destinationAddress;
+    }
+
+    /**
+     * Returns the remaining data behind the IP header. Modifying the content of the returned buffer
+     * or this packet's buffer affects each other's content while they maintain separate indexes and
+     * marks.
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the reference count
+     * will NOT be increased.
+     */
+    public ByteBuf data() {
+        return content().slice(INET6_HEADER_LENGTH, content().readableBytes() - INET6_HEADER_LENGTH);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(StringUtil.simpleClassName(this))
+                .append('[')
+                .append("len=").append(payloadLength())
+                .append(", src=").append(sourceAddress().getHostAddress())
+                .append(", dst=").append(destinationAddress().getHostAddress())
+                .append(']').toString();
+    }
+}

--- a/transport/src/main/java/io/netty/channel/socket/TunAddress.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunAddress.java
@@ -25,10 +25,19 @@ public class TunAddress extends SocketAddress {
     private static final long serialVersionUID = -584786182484350484L;
     private final String ifName;
 
+    /**
+     * Creates a new instance.
+     * <p>
+     * If {@code ifName} is {@code null} the platform will select a free name when passed to
+     * {@link io.netty.channel.Channel#bind(SocketAddress)}.
+     */
     public TunAddress(String ifName) {
         this.ifName = ifName;
     }
 
+    /**
+     * Creates a new instance with {@code null} as {@link #ifName()}.
+     */
     public TunAddress() {
         this(null);
     }

--- a/transport/src/main/java/io/netty/channel/socket/TunAddress.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunAddress.java
@@ -42,10 +42,6 @@ public class TunAddress extends SocketAddress {
 
     @Override
     public String toString() {
-        if (ifName == null) {
-            return "";
-        } else {
-            return ifName;
-        }
+        return "Tun Interface: " + ifName;
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/TunAddress.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunAddress.java
@@ -35,8 +35,6 @@ public class TunAddress extends SocketAddress {
 
     /**
      * Returns the name of the tun device.
-     *
-     * @return the name of the tun device
      */
     public String ifName() {
         return ifName;

--- a/transport/src/main/java/io/netty/channel/socket/TunAddress.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunAddress.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import java.net.SocketAddress;
+
+/**
+ * A {@link SocketAddress} implementation that identifies a tun device to which a {@link TunChannel}
+ * can be bound to.
+ */
+public class TunAddress extends SocketAddress {
+    private static final long serialVersionUID = -584786182484350484L;
+    private final String ifName;
+
+    public TunAddress(String ifName) {
+        this.ifName = ifName;
+    }
+
+    public TunAddress() {
+        this(null);
+    }
+
+    /**
+     * Returns the name of the tun device.
+     *
+     * @return the name of the tun device
+     */
+    public String ifName() {
+        return ifName;
+    }
+
+    @Override
+    public String toString() {
+        if (ifName == null) {
+            return "";
+        } else {
+            return ifName;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/socket/TunChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,13 +13,18 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel.kqueue;
+package io.netty.channel.socket;
 
 import io.netty.channel.Channel;
 
-@Deprecated
-abstract class AbstractKQueueDatagramChannel extends AbstractKQueueMessageChannel {
-    AbstractKQueueDatagramChannel(final Channel parent, final BsdSocket fd, final boolean active) {
-        super(parent, fd, active);
-    }
+import java.io.IOException;
+
+/**
+ * A TUN device-backed {@link Channel}.
+ */
+public interface TunChannel extends Channel {
+    @Override
+    TunAddress localAddress();
+
+    int mtu() throws IOException;
 }

--- a/transport/src/main/java/io/netty/channel/socket/TunChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunChannelConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.channel.ChannelConfig;
+
+/**
+ * A {@link ChannelConfig} for a {@link TunChannel}.
+ *
+ * <h3>Available options</h3>
+ * <p>
+ * In addition to the options provided by {@link ChannelConfig}, {@link TunChannelConfig} allows the
+ * following options in the option map:
+ *
+ * <table border="1" cellspacing="0" cellpadding="6">
+ * <tr>
+ * <th>Name</th><th>Associated setter method</th>
+ * </tr><tr>
+ * <td>{@link TunChannelOption#TUN_MTU}</td><td>{@link #setMtu(int)}</td>
+ * </tr>
+ * </table>
+ */
+public interface TunChannelConfig extends ChannelConfig {
+    /**
+     * Gets the {@link TunChannelOption#TUN_MTU} option.
+     */
+    int getMtu();
+
+    /**
+     * Sets the {@link TunChannelOption#TUN_MTU} option.
+     */
+    TunChannelConfig setMtu(int mtu);
+}

--- a/transport/src/main/java/io/netty/channel/socket/TunChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunChannelOption.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.channel.ChannelOption;
+
+/**
+ * Provides {@link ChannelOption}s for {@link TunChannel}s.
+ */
+public final class TunChannelOption<T> extends ChannelOption<T> {
+    /**
+     * Defines MTU for the created tun device.
+     * <p>
+     * Increasing the MTU may also require you to adjust {@link #RCVBUF_ALLOCATOR}.
+     * It is necessary, that the {@link #RCVBUF_ALLOCATOR} always yields buffers that can hold a complete IP packet.
+     * <p>
+     * If kqueue is used, buffers capacity must be at least 4 bytes greater than the MTU.
+     */
+    public static final ChannelOption<Integer> TUN_MTU = valueOf("TUN_MTU");
+
+    private TunChannelOption() {
+        super(null);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/socket/TunPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunPacket.java
@@ -34,7 +34,7 @@ public abstract class TunPacket extends DefaultByteBufHolder {
     /**
      * Returns the IP version.
      */
-    public abstract int version();
+    public abstract InternetProtocolFamily version();
 
     /**
      * Returns the source address.

--- a/transport/src/main/java/io/netty/channel/socket/TunPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunPacket.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+
+import java.net.InetAddress;
+
+/**
+ * Envelope class for IPv4 and IPv6 packets received from/sent to TUN devices.
+ *
+ * @see Tun4Packet
+ * @see Tun6Packet
+ */
+public abstract class TunPacket extends DefaultByteBufHolder {
+    protected TunPacket(ByteBuf data) {
+        super(data);
+    }
+
+    /**
+     * Returns the IP version.
+     *
+     * @return the IP version.
+     */
+    public abstract int version();
+
+    /**
+     * Returns the source address.
+     *
+     * @return the source address.
+     */
+    public abstract InetAddress sourceAddress();
+
+    /**
+     * Returns the destination address.
+     *
+     * @return the destination address.
+     */
+    public abstract InetAddress destinationAddress();
+}

--- a/transport/src/main/java/io/netty/channel/socket/TunPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/TunPacket.java
@@ -33,22 +33,16 @@ public abstract class TunPacket extends DefaultByteBufHolder {
 
     /**
      * Returns the IP version.
-     *
-     * @return the IP version.
      */
     public abstract int version();
 
     /**
      * Returns the source address.
-     *
-     * @return the source address.
      */
     public abstract InetAddress sourceAddress();
 
     /**
      * Returns the destination address.
-     *
-     * @return the destination address.
      */
     public abstract InetAddress destinationAddress();
 }

--- a/transport/src/test/java/io/netty/channel/socket/Tun4PacketTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/Tun4PacketTest.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty.channel.socket.InternetProtocolFamily.IPv4;
 import static io.netty.channel.socket.Tun4Packet.INET4_FLAGS_DONT_FRAGMENT_MASK;
 import static io.netty.channel.socket.Tun4Packet.INET4_FLAGS_MORE_FRAGMENTS_MASK;
 import static io.netty.channel.socket.Tun4Packet.INET4_TYPE_OF_SERVICE_DELAY_MASK;
@@ -96,7 +97,7 @@ public class Tun4PacketTest {
 
     @Test
     void testVersion() {
-        assertEquals(4, packet.version());
+        assertEquals(IPv4, packet.version());
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/socket/Tun4PacketTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/Tun4PacketTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import com.google.common.primitives.Ints;
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty.channel.socket.Tun4Packet.INET4_FLAGS_DONT_FRAGMENT_MASK;
+import static io.netty.channel.socket.Tun4Packet.INET4_FLAGS_MORE_FRAGMENTS_MASK;
+import static io.netty.channel.socket.Tun4Packet.INET4_TYPE_OF_SERVICE_DELAY_MASK;
+import static io.netty.channel.socket.Tun4Packet.INET4_TYPE_OF_SERVICE_PRECEDENCE_ROUTINE;
+import static io.netty.channel.socket.Tun4Packet.INET4_TYPE_OF_SERVICE_RELIBILITY_MASK;
+import static io.netty.channel.socket.Tun4Packet.INET4_TYPE_OF_SERVICE_THROUGHPUT_MASK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Tun4PacketTest {
+    private ByteBuf data;
+    private Tun4Packet packet;
+
+    @BeforeEach
+    void setUp() {
+        data = wrappedBuffer(new byte[]{
+                // IPv4
+                (byte) 0x45, // version,
+                (byte) 0x00, // internet header length
+                (byte) 0x00, (byte) 0x3e, // header length
+                (byte) 0xf0, (byte) 0x7d, // identification
+                (byte) 0x40, (byte) 0x00, // flags (dont fragment)
+                (byte) 0x01, // time to live
+                (byte) 0x11, // protocol (UDP)
+                (byte) 0x06, (byte) 0x01, // header checksum
+                (byte) 0x0a, (byte) 0xe1, (byte) 0xd7, (byte) 0x54, // source address
+                (byte) 0xe0, (byte) 0x00, (byte) 0x00, (byte) 0xfb, // destination address
+                // UDP
+                (byte) 0x14, (byte) 0xe9, // source port
+                (byte) 0x14, (byte) 0xe9, // destination port
+                (byte) 0x00, (byte) 0x2a, // length
+                (byte) 0x95, (byte) 0x7a, // checksum
+                // Multicast DNS
+                (byte) 0x00, (byte) 0x00, // transaction id
+                (byte) 0x00, (byte) 0x00, // flags
+                (byte) 0x00, (byte) 0x01, // questions
+                (byte) 0x00, (byte) 0x00, // answer resource records
+                (byte) 0x00, (byte) 0x00, // authority resource records
+                (byte) 0x00, (byte) 0x00, // additional resource records
+                // additional resource records
+                (byte) 0x0a, (byte) 0x72, (byte) 0x6d, (byte) 0x77, (byte) 0x79, (byte) 0x7a,
+                (byte) 0x64, (byte) 0x69, (byte) 0x76, (byte) 0x75, (byte) 0x75, (byte) 0x05,
+                (byte) 0x6c, (byte) 0x6f, (byte) 0x63, (byte) 0x61, (byte) 0x6c, (byte) 0x00,
+                (byte) 0x00, (byte) 0x01, // type (A)
+                (byte) 0x00, (byte) 0x01, // class (IN)
+        });
+        packet = new Tun4Packet(data);
+    }
+
+    @Test
+    void testConstructor() {
+        // create too short byte buf
+        final ByteBuf buf = packet.content().readBytes(19);
+        try {
+            assertThrows(IllegalArgumentException.class, new Executable() {
+                @Override
+                public void execute() {
+                    new Tun4Packet(buf);
+                }
+            });
+        } finally {
+            if (buf != null) {
+                buf.release();
+            }
+        }
+    }
+
+    @Test
+    void testVersion() {
+        assertEquals(4, packet.version());
+    }
+
+    @Test
+    void testInternetHeaderLength() {
+        assertEquals(5, packet.internetHeaderLength());
+    }
+
+    @Test
+    void testTypeOfService() {
+        assertEquals(0, packet.typeOfService());
+        assertEquals(INET4_TYPE_OF_SERVICE_PRECEDENCE_ROUTINE, packet.typeOfService() >> 5);
+        assertFalse((packet.typeOfService() & INET4_TYPE_OF_SERVICE_DELAY_MASK) > 0);
+        assertFalse((packet.typeOfService() & INET4_TYPE_OF_SERVICE_THROUGHPUT_MASK) > 0);
+        assertFalse((packet.typeOfService() & INET4_TYPE_OF_SERVICE_RELIBILITY_MASK) > 0);
+    }
+
+    @Test
+    void testTotalLength() {
+        assertEquals(62, packet.totalLength());
+    }
+
+    @Test
+    void testIdentification() {
+        assertEquals(61565, packet.identification());
+    }
+
+    @Test
+    void testFlags() {
+        assertEquals(2, packet.flags());
+        assertTrue((packet.flags() & INET4_FLAGS_DONT_FRAGMENT_MASK) > 0);
+        assertFalse((packet.flags() & INET4_FLAGS_MORE_FRAGMENTS_MASK) > 0);
+    }
+
+    @Test
+    void testFragmentOffset() {
+        assertEquals(0, packet.fragmentOffset());
+    }
+
+    @Test
+    void testTimeToLive() {
+        assertEquals(1, packet.timeToLive());
+    }
+
+    @Test
+    void testProtocol() {
+        assertEquals(17, packet.protocol());
+    }
+
+    @Test
+    void testHeaderChecksum() {
+        assertEquals(1537, packet.headerChecksum());
+    }
+
+    @Test
+    void testSourceAddress() throws UnknownHostException {
+        assertEquals(InetAddress.getByName("10.225.215.84"), packet.sourceAddress());
+    }
+
+    @Test
+    void testDestinationAddress() throws UnknownHostException {
+        assertEquals(InetAddress.getByName("224.0.0.251"), packet.destinationAddress());
+    }
+
+    @Test
+    void testData() {
+        assertEquals(data.slice(20, 42), packet.data());
+    }
+
+    @Test
+    void testToString() {
+        assertEquals("Tun4Packet[id=61565, len=62, src=10.225.215.84, dst=224.0.0.251]", packet.toString());
+    }
+
+    @Test
+    void verifyChecksum() {
+        // from https://en.wikipedia.org/w/index.php?title=Internet_checksum&oldid=1096765534
+        ByteBuf buf = wrappedBuffer(new byte[]{
+                (byte) 0x45, (byte) 0x00, (byte) 0x00, (byte) 0x73, (byte) 0x00, (byte) 0x00,
+                (byte) 0x40, (byte) 0x00, (byte) 0x40, (byte) 0x11, (byte) 0xb8, (byte) 0x61,
+                (byte) 0xc0, (byte) 0xa8, (byte) 0x00, (byte) 0x01, (byte) 0xc0, (byte) 0xa8,
+                (byte) 0x00, (byte) 0xc7
+        });
+
+        Tun4Packet tun4Packet = new Tun4Packet(buf);
+        assertTrue(tun4Packet.verifyChecksum());
+    }
+
+    @Test
+    void calculateChecksum() {
+        // from https://en.wikipedia.org/w/index.php?title=Internet_checksum&oldid=1096765534
+        ByteBuf buf = wrappedBuffer(new byte[]{
+                (byte) 0x45, (byte) 0x00, (byte) 0x00, (byte) 0x73, (byte) 0x00, (byte) 0x00,
+                (byte) 0x40, (byte) 0x00, (byte) 0x40, (byte) 0x11, (byte) 0x00, (byte) 0x00,
+                (byte) 0xc0, (byte) 0xa8, (byte) 0x00, (byte) 0x01, (byte) 0xc0, (byte) 0xa8,
+                (byte) 0x00, (byte) 0xc7
+        });
+
+        assertEquals(Ints.fromByteArray(new byte[]{
+                (byte) 0x00, (byte) 0x00, (byte) 0xb8, (byte) 0x61
+        }), Tun4Packet.calculateChecksum(buf));
+    }
+}

--- a/transport/src/test/java/io/netty/channel/socket/Tun6PacketTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/Tun6PacketTest.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty.channel.socket.InternetProtocolFamily.IPv6;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -89,7 +90,7 @@ public class Tun6PacketTest {
 
     @Test
     void testVersion() {
-        assertEquals(6, packet.version());
+        assertEquals(IPv6, packet.version());
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/socket/Tun6PacketTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/Tun6PacketTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Tun6PacketTest {
+    private Tun6Packet packet;
+    private ByteBuf data;
+
+    @BeforeEach
+    void setUp() {
+        data = wrappedBuffer(new byte[]{
+                // IPv6
+                (byte) 0x60, // version and traffic class
+                (byte) 0x26, (byte) 0x0c, (byte) 0x00, // traffic class and flow label
+                (byte) 0x00, (byte) 0x75, // payload length
+                (byte) 0x06, // next header
+                (byte) 0x40, // hop limit
+                // source address
+                (byte) 0xfe, (byte) 0x80, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x1c, (byte) 0xdf, (byte) 0x17, (byte) 0x4b,
+                (byte) 0x91, (byte) 0xdf, (byte) 0x64, (byte) 0x07,
+                // destination address
+                (byte) 0xfe, (byte) 0x80, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x66, (byte) 0x44, (byte) 0x5e,
+                (byte) 0xbe, (byte) 0xdf, (byte) 0xf8, (byte) 0x43,
+                // TCP
+                (byte) 0xc3, (byte) 0x82, // source port
+                (byte) 0x1b, (byte) 0x58, // destination port
+                (byte) 0xe4, (byte) 0x02, (byte) 0x37, (byte) 0x5a, // sequence number
+                (byte) 0x8f, (byte) 0xdb, (byte) 0x71, (byte) 0xbf, // acknowledgement number
+                (byte) 0xc3, // data offset and reserved
+                (byte) 0x18, // control bits (congestion window reduced)
+                (byte) 0x08, (byte) 0x00, // window
+                (byte) 0xbe, (byte) 0xdb, // checksum
+                (byte) 0x00, (byte) 0x00, // urgent pointer
+                (byte) 0x01, (byte) 0x01, // 2x option
+                (byte) 0x08, // kind
+                (byte) 0x10, // length
+                (byte) 0x17, (byte) 0x8b, (byte) 0x2a, (byte) 0x50, // timestamp value
+                (byte) 0xde, (byte) 0x25, (byte) 0x08, (byte) 0xf3, // timestamp echo reply
+        });
+        packet = new Tun6Packet(data);
+    }
+
+    @Test
+    void testConstructor() {
+        // create too short byte buf
+        final ByteBuf buf = packet.content().readBytes(39);
+        try {
+            assertThrows(IllegalArgumentException.class, new Executable() {
+                @Override
+                public void execute() {
+                    new Tun6Packet(buf);
+                }
+            });
+        } finally {
+            if (buf != null) {
+                buf.release();
+            }
+        }
+    }
+
+    @Test
+    void testVersion() {
+        assertEquals(6, packet.version());
+    }
+
+    @Test
+    void testTrafficClass() {
+        assertEquals(2, packet.trafficClass());
+    }
+
+    @Test
+    void testFlowLabel() {
+        assertEquals(396288, packet.flowLabel());
+    }
+
+    @Test
+    void testPayloadLength() {
+        assertEquals(117, packet.payloadLength());
+    }
+
+    @Test
+    void testNextHeader() {
+        assertEquals(6, packet.nextHeader());
+    }
+
+    @Test
+    void testHopLimit() {
+        assertEquals(64, packet.hopLimit());
+    }
+
+    @Test
+    void testSourceAddress() throws UnknownHostException {
+        assertEquals(InetAddress.getByName("fe80:0:0:0:1cdf:174b:91df:6407"), packet.sourceAddress());
+    }
+
+    @Test
+    void testDestinationAddress() throws UnknownHostException {
+        assertEquals(InetAddress.getByName("fe80:0:0:0:66:445e:bedf:f843"), packet.destinationAddress());
+    }
+
+    @Test
+    void testData() {
+        assertEquals(data.slice(40, 32), packet.data());
+    }
+
+    @Test
+    void testToString() {
+        assertEquals(
+                "Tun6Packet[len=117, src=fe80:0:0:0:1cdf:174b:91df:6407, dst=fe80:0:0:0:66:445e:bedf:f843]",
+                packet.toString()
+        );
+    }
+}


### PR DESCRIPTION
* Added check if `IFF_MULTI_QUEUE` is available when building `netty-transport-native-epoll`.
* Added `io.netty.channel.epoll.Native.IS_SUPPORTING_MULTI_QUEUE`, allowing to check if `IFF_MULTI_QUEUE` feature is available.
* Added tests for epoll and kqueue (currently, only UDP-based traffic is processed. I don't see any advantages of adding a TCP-based test as well, as it makes no difference for the TUN device. But if you insist, I can add it).
* Adjusted `docker/docker-compose.yaml` to make TUN tests work in CI.